### PR TITLE
add indicator widget for page navigation

### DIFF
--- a/lib/core/design_system/widgets/indicator.dart
+++ b/lib/core/design_system/widgets/indicator.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:sellio_mobile/core/design_system/themes/sellio_theme_provider.dart';
+
+class Indicator extends StatelessWidget {
+  final int pages;
+  final int currentPage;
+
+  const Indicator({
+    super.key,
+    required this.pages,
+    required this.currentPage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(
+        pages,
+            (index) {
+          final bool isActive = index == currentPage;
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 300),
+            margin: const EdgeInsets.symmetric(horizontal: 2),
+            width: isActive ? 6 : 4,
+            height: isActive ? 6 : 4,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isActive
+                  ? colors.secondary
+                  : colors.stroke,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR includes:

- Implementation of the Indicator component.

How to use it:
1. Specify the total number of pages, for example: `pages: 3`
2. Set the current page index, for example: `currentPage: 0` (ranges from 0 to the total number of pages - 1)

[Screencast from 10-26-2025 12:40:05 AM.webm](https://github.com/user-attachments/assets/4dbcc273-0e37-4556-b385-44ee8f691cb9)
