### PR TITLE
feat: Rename app to "sellio"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="sellio_mobile"
+        android:label="Sellio"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>
-		<string>Sellio Mobile</string>
+		<string>Sellio</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Changes the application display name from "sellio_mobile" to "sellio" on Android and iOS platforms.

Before:

<img width="203" height="189" alt="Screenshot from 2025-10-30 18-28-37" src="https://github.com/user-attachments/assets/85ed7cd0-068b-4c28-806f-0da5e086c5fa" />

After: 

<img width="203" height="189" alt="Screenshot from 2025-10-30 18-27-16" src="https://github.com/user-attachments/assets/e7ed7a89-00f8-416f-a0a3-ea11f0e22a62" />
