### PR TITLE
Fix: Run CI only before merge, not after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
-    types: [opened, closed, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description
- This update ensures the CI pipeline runs only before a merge (on pull requests), not after.

- Previously, the workflow was triggered on both push and pull_request events, causing redundant runs after merges to main or develop.

## What Changed
- Removed push trigger from the workflow.
- CI now runs only on pull_request and manual workflow_dispatch events.
- Prevents unnecessary post-merge runs and reduces redundant build time.

## Screenshots/Videos (if applicable)
<!-- Add screenshots or videos to help explain your changes -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

## Additional Notes

