### PR TITLE
fix: correct import path for CustomDesignScreen

### DIFF
--- a/lib/core/app_management/route/route_manager.dart
+++ b/lib/core/app_management/route/route_manager.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sellio_mobile/core/app_management/route/route_args.dart';
-import 'package:sellio_mobile/ui/screens/CustomDesignScreen.dart';
+import '../../../ui/screens/customDesignScreen.dart';
 import 'package:sellio_mobile/ui/screens/auth/login.dart';
 import 'package:sellio_mobile/ui/screens/home/home_screen.dart';
 import 'package:sellio_mobile/ui/screens/account_screen.dart';


### PR DESCRIPTION
## Description
Fixed a compile error caused by an incorrect import path for CustomDesignScreen.
Updated the import to use the correct relative path.


