### PR TITLE
Ignore pubspec.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+pubspec.lock
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
## Description
Add pubspec.lock to .gitignore to prevent it from being tracked in Git. 
This helps avoid unnecessary merge conflicts and keeps the repository clean.## What Changed
