### PR TITLE
refactor(thrift): Improve state management and UI structure

### DIFF
--- a/lib/presentation/screens/thrift_screen.dart
+++ b/lib/presentation/screens/thrift_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sellio_mobile/core/design_system/themes/sellio_theme_provider.dart';
 import 'package:sellio_mobile/core/design_system/widgets/sellio_app_bar.dart';
+import '../../core/design_system/constants/assets.dart';
 import '../../core/design_system/widgets/cards/product_vertical_card.dart';
 import 'home/widgets/category_tabs.dart';
 
@@ -12,6 +13,8 @@ class ThriftScreen extends StatefulWidget {
 }
 
 class _ThriftScreenState extends State<ThriftScreen> {
+  int selectedCategory = 0;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
@@ -19,35 +22,40 @@ class _ThriftScreenState extends State<ThriftScreen> {
     return Scaffold(
       backgroundColor: colors.surfaceLow,
       appBar: const SellioAppBar(title: 'Thrift'),
-      body: CustomScrollView(slivers: [
-        CategoryTabs(
-          categories: const [
-            CategoryTabData(
-                id: 'all', name: 'All', icon: 'assets/icons/all_icon.svg'),
-            CategoryTabData(
-                id: 'clothes',
-                name: 'Clothes',
-                icon: 'assets/icons/clothes_icon.svg'),
-            CategoryTabData(
-                id: 'furniture',
-                name: 'Furniture',
-                icon: 'assets/icons/furniture_icon.svg'),
-            CategoryTabData(
-                id: 'electronics',
-                name: 'Electronics',
-                icon: 'assets/icons/electronics_icon.svg'),
-            CategoryTabData(
-                id: 'books',
-                name: 'Books',
-                icon: 'assets/icons/books_icon.svg'),
-          ],
-          selectedIndex: 0,
-          onCategorySelected: (index) {
-            // Handle category selection
-          },
-        ),
-        GridProductsSection()
-      ]),
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: CategoryTabs(
+              categories: const [
+                CategoryTabData(
+                    id: 'all', name: 'All', icon: Assets.allCategories),
+                CategoryTabData(
+                    id: 'clothes',
+                    name: 'Clothes',
+                    icon: Assets.clothes),
+                CategoryTabData(
+                    id: 'furniture',
+                    name: 'Furniture',
+                    icon: Assets.clothes),
+                CategoryTabData(
+                    id: 'electronics',
+                    name: 'Electronics',
+                    icon: Assets.clothes),
+                CategoryTabData(
+                    id: 'books',
+                    name: 'Books',
+                    icon: Assets.clothes),
+              ],
+              selectedIndex: selectedCategory,
+              onCategorySelected: (index) {
+                setState(() => selectedCategory = index);
+              },
+            ),
+          ),
+          const SliverPadding(padding: EdgeInsets.only(top: 8)),
+          const GridProductsSection(),
+        ],
+      ),
     );
   }
 }
@@ -61,123 +69,112 @@ class GridProductsSection extends StatefulWidget {
 
 class _GridProductsSectionState extends State<GridProductsSection> {
   final Map<int, int> _productCounts = {};
-  bool _isFavourite = false;
+  final Map<int, bool> _favorites = {};
+
+  final List<Map<String, dynamic>> _products = [
+    {
+      'id': 0,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Gold Stainless Steel Sun Charm Necklace',
+      'price': '\$5.00',
+    },
+    {
+      'id': 1,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Birthday cake with bows',
+      'price': '\$12.99',
+    },
+    {
+      'id': 2,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Product Name 3',
+      'price': '\$30.99',
+    },
+    {
+      'id': 3,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Birthday cake with bows',
+      'price': '\$12.99',
+    },
+    {
+      'id': 4,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Product Name 4',
+      'price': '\$30.99',
+    },
+    {
+      'id': 5,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Product Name 5',
+      'price': '\$25.50',
+    },
+    {
+      'id': 6,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Birthday cake with bows',
+      'price': '\$12.99',
+    },
+    {
+      'id': 7,
+      'imageUrl': 'assets/images/product_3.webp',
+      'title': 'Product Name 7',
+      'price': '\$30.99',
+    },
+  ];
+
+  void _incrementProduct(int productId) {
+    setState(() {
+      _productCounts[productId] = (_productCounts[productId] ?? 0) + 1;
+    });
+  }
+
+  void _decrementProduct(int productId) {
+    setState(() {
+      final count = _productCounts[productId] ?? 0;
+      if (count > 0) {
+        _productCounts[productId] = count - 1;
+      }
+    });
+  }
+
+  void _toggleFavorite(int productId) {
+    setState(() {
+      _favorites[productId] = !(_favorites[productId] ?? false);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    final List<Map<String, dynamic>> products = [
-      {
-        'id': 0,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Gold Stainless Steel Sun Charm Necklace',
-        'price': '\$5.00',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 1,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Birthday cake with bows',
-        'price': '\$12.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 3,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Product Name 3',
-        'price': '\$30.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 4,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Birthday cake with bows',
-        'price': '\$12.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 5,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Product Name 3',
-        'price': '\$30.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 6,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Product Name 3',
-        'price': '\$30.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 7,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Birthday cake with bows',
-        'price': '\$12.99',
-        'isFavourite': _isFavourite,
-      },
-      {
-        'id': 8,
-        'imageUrl': 'assets/images/product_3.webp',
-        'title': 'Product Name 3',
-        'price': '\$30.99',
-        'isFavourite': _isFavourite,
-      },
-    ];
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      sliver: SliverGrid(
+        delegate: SliverChildBuilderDelegate(
+              (context, index) {
+            final product = _products[index];
+            final productId = product['id'] as int;
+            final count = _productCounts[productId] ?? 0;
+            final isFavorite = _favorites[productId] ?? false;
 
-    void incrementProduct(int productId) {
-      setState(() {
-        _productCounts[productId] = (_productCounts[productId] ?? 0) + 1;
-      });
-    }
-
-    void decrementProduct(int productId) {
-      setState(() {
-        final count = _productCounts[productId] ?? 0;
-        if (count > 0) {
-          _productCounts[productId] = count - 1;
-        }
-      });
-    }
-
-    void toggleFavourite(int productId) {
-      setState(() {
-        _isFavourite = !_isFavourite;
-      });
-    }
-
-    return SliverToBoxAdapter(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          GridView.builder(
-            physics: const NeverScrollableScrollPhysics(),
-            shrinkWrap: true,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            itemCount: products.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              crossAxisSpacing: 8,
-              mainAxisSpacing: 12,
-              childAspectRatio: 170 / 272,
-            ),
-            itemBuilder: (context, index) {
-              final product = products[index];
-              final productId = product['id'] as int;
-              final count = _productCounts[productId] ?? 0;
-
-              return ProductVerticalCard(
-                imageUrl: product['imageUrl'],
-                title: product['title'],
-                price: product['price'],
-                count: count,
-                isFavorite: product['isFavourite'],
-                onIncrement: () => incrementProduct(productId),
-                onDecrement: () => decrementProduct(productId),
-                onFavorite: () => toggleFavourite(productId),
-              );
-            },
-          ),
-        ],
+            return ProductVerticalCard(
+              key: ValueKey(productId),
+              imageUrl: product['imageUrl'],
+              title: product['title'],
+              price: product['price'],
+              count: count,
+              isFavorite: isFavorite,
+              onIncrement: () => _incrementProduct(productId),
+              onDecrement: () => _decrementProduct(productId),
+              onFavorite: () => _toggleFavorite(productId),
+            );
+          },
+          childCount: _products.length,
+        ),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          crossAxisSpacing: 8,
+          mainAxisSpacing: 12,
+          childAspectRatio: 170 / 272,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Refactors the `ThriftScreen` for better state management and a more efficient widget structure.

- Converts `ThriftScreen` to a `StatefulWidget` to manage the selected category index.
- Implements state handling for individual product favorite toggling, ensuring each product card maintains its own favorite status.
- Replaces hardcoded icon paths with constants from `Assets`.
- Refactors the `GridProductsSection` to use `SliverGrid` and `SliverPadding` directly within the `CustomScrollView`, removing an unnecessary `SliverToBoxAdapter` and `Column`.
- Adds a `SliverPadding` for better spacing between the category tabs and the product grid.



https://github.com/user-attachments/assets/8a07ec3e-c90b-4fd3-aa25-527dc766f8b5

