### PR TITLE
ci: Add Discord PR notification workflow

### DIFF
--- a/.github/workflows/notify-discord-pr.yml
+++ b/.github/workflows/notify-discord-pr.yml
@@ -1,0 +1,52 @@
+name: Notify Discord for PRs to Develop
+
+on:
+  pull_request:
+    types: [ opened ]
+    branches:
+      - develop
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Notification to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          pr_title="${{ github.event.pull_request.title }}"
+          pr_url="${{ github.event.pull_request.html_url }}"
+          pr_user="${{ github.event.pull_request.user.login }}"
+
+          json_payload=$(jq -n \
+            --arg title "$pr_title" \
+            --arg url "$pr_url" \
+            --arg user "$pr_user" \
+            '
+            {
+              "embeds": [
+                {
+                  "title": $title,
+                  "url": $url,
+                  "description": "**New Pull Request → `develop`**",
+                  "color": 5814783,
+                  "fields": [
+                    {
+                      "name": "Author",
+                      "value": $user,
+                      "inline": true
+                    }
+                  ],
+                  "footer": {
+                    "text": "🔥 Please review as soon as possible"
+                  }
+                }
+              ]
+            }
+            ')
+
+          echo "Sending message to Discord..."
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "$json_payload" \
+               "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
Adds a new GitHub Actions workflow to send a notification to a Discord channel when a new pull request is opened against the `develop` branch.

## Description
Adds a new GitHub Actions workflow that sends a notification to a Discord channel whenever a new pull request is opened against the develop branch. This helps the team stay informed about new PRs and speeds up code reviews.

## What Changed
Added a new workflow file: .github/workflows/notify-discord-pr.yml