### PR TITLE
fix: back button in top bar navigates to previous screen

### DIFF
--- a/packages/design_system/lib/widgets/sellio_app_bar.dart
+++ b/packages/design_system/lib/widgets/sellio_app_bar.dart
@@ -57,8 +57,9 @@ class SellioAppBar extends StatelessWidget implements PreferredSizeWidget {
         padding: const EdgeInsets.only(left: _leadingPadding),
         child: IconButton(
           icon: SvgPicture.asset(AppImages.arrowLeft),
-          onPressed: (){},
-          //onPressed: () => context.navigator.pop(),
+          onPressed: (){
+            Navigator.of(context).pop();
+          },
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(),
           iconSize: _backIconSize,


### PR DESCRIPTION
## Description
Fixes an issue where the back button in the top app bar was not navigating to the previous screen.

