### PR TITLE
feat(search): Add icons to search filter chips

### DIFF
--- a/apps/customer/lib/presentation/screens/search/widgets/category_section.dart
+++ b/apps/customer/lib/presentation/screens/search/widgets/category_section.dart
@@ -21,12 +21,20 @@ class CategorySection extends StatelessWidget {
             children: [
               SellioChip(
                 label: context.local.products,
+                assetIcon: AppImages.product,
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                  8, 6, 12, 6,
+                ),
                 selected: state.selectedType == SearchType.products,
                 onTap: () => cubit.selectTab(SearchType.products),
               ),
               const Gap(8),
               SellioChip(
                 label: context.local.stores,
+                assetIcon: AppImages.storeIcon,
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                  8, 6, 12, 6,
+                ),
                 selected: state.selectedType == SearchType.stores,
                 onTap: () => cubit.selectTab(SearchType.stores),
               ),

--- a/apps/customer/lib/presentation/screens/search/widgets/recent_search.dart
+++ b/apps/customer/lib/presentation/screens/search/widgets/recent_search.dart
@@ -53,6 +53,10 @@ class RecentSearchSection extends StatelessWidget {
               return SellioChip(
                 label: text,
                 selected: false,
+                padding: const EdgeInsetsDirectional.symmetric(
+                  horizontal: 16,
+                  vertical: 11,
+                ),
                 onTap: () {
                   searchController.text = text;
                   cubit.selectRecent(text);

--- a/packages/design_system/lib/widgets/sellio_chip.dart
+++ b/packages/design_system/lib/widgets/sellio_chip.dart
@@ -66,7 +66,9 @@ class SellioChip extends StatelessWidget {
               ],
               Text(
                 label,
-                style: TextStyle(color: contentColor),
+                style: context.theme.typography.textTheme.labelSmall.copyWith(
+                  color: contentColor,
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
This commit enhances the search screen's UI by adding icons to the "Products" and "Stores" filter chips.

- The "Products" chip now displays a product icon (`AppImages.product`).
- The "Stores" chip now displays a store icon (`AppImages.storeIcon`).
- Padding for the chips has been adjusted to accommodate the new icons.

<img width="475" height="515" alt="image" src="https://github.com/user-attachments/assets/85b29a9a-882e-42d4-9d2a-12c66c2f9425" />

<img width="522" height="167" alt="image" src="https://github.com/user-attachments/assets/83c19117-e6c8-4fe8-bc38-60509dfb16b9" />


## Additional Notes

