### PR TITLE
Refactor(auth): Differentiate reset password endpoints

### DIFF
--- a/apps/customer/lib/data/core/api/api_endpoints.dart
+++ b/apps/customer/lib/data/core/api/api_endpoints.dart
@@ -12,7 +12,8 @@ class ApiEndpoints {
   static const String resendOtp = '$apiVersion/auth/resend-otp';
   static const String forgotPassword = '$apiVersion/forgot-password/request';
   static const String verifyForgotPasswordOtp = '$apiVersion/forgot-password/verify';
-  static const String resetPassword = '$apiVersion/forgot-password/reset';
+  static const String resetForgotPassword = '$apiVersion/forgot-password/reset';
+  static const String resetPassword = '$apiVersion/auth/reset-password';
   static const String requestOtp = '$apiVersion/auth/create/request-otp';
   static const String verifyOtp = '$apiVersion/auth/create/verify-otp';
   static const String register = '$apiVersion/auth/create';

--- a/apps/customer/lib/data/datasource/remote/auth/auth_remote_datasource_impl.dart
+++ b/apps/customer/lib/data/datasource/remote/auth/auth_remote_datasource_impl.dart
@@ -143,7 +143,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     );
 
     await _apiClient.post(
-      ApiEndpoints.resetPassword,
+      ApiEndpoints.resetForgotPassword,
       data: request.toJson(),
     );
   }

--- a/apps/customer/lib/data/repositories/user_repository_impl.dart
+++ b/apps/customer/lib/data/repositories/user_repository_impl.dart
@@ -94,58 +94,6 @@ class UserRepositoryImpl implements UserRepository {
   }
 
   @override
-  Future<Result<Address>> getUserAddress() async {
-    return RepositoryCallHandler.call<Address>(() async {
-      final model = await _remoteDataSource.getUserAddress();
-      return model.toEntity();
-    });
-  }
-
-  @override
-  Future<Result<Address>> addAddress({
-    required String country,
-    required String city,
-  }) async {
-    return RepositoryCallHandler.call<Address>(() async {
-      final request = AddAddressRequest(
-        country: country,
-        city: city,
-      );
-
-      final model = await _remoteDataSource.addAddress(request);
-      return model.toEntity();
-    });
-  }
-
-  @override
-  Future<Result<Address>> updateAddress({
-    required String addressId,
-    String? country,
-    String? city,
-  }) async {
-    return RepositoryCallHandler.call<Address>(() async {
-      final request = UpdateAddressRequest(
-        country: country,
-        city: city,
-      );
-
-      final model = await _remoteDataSource.updateAddress(
-        addressId: addressId,
-        request: request,
-      );
-
-      return model.toEntity();
-    });
-  }
-
-  @override
-  Future<Result<void>> deleteAddress(String addressId) async {
-    return RepositoryCallHandler.callVoid(
-          () => _remoteDataSource.deleteAddress(addressId),
-    );
-  }
-
-  @override
   Future<Result<String>> uploadProfilePhoto(String filePath) async {
     return RepositoryCallHandler.call<String>(() async {
       return await _remoteDataSource.uploadProfilePhoto(filePath: filePath);

--- a/apps/customer/lib/domain/repositories/user_repository.dart
+++ b/apps/customer/lib/domain/repositories/user_repository.dart
@@ -28,20 +28,5 @@ abstract class UserRepository {
 
   Future<Result<void>> deleteAccount();
 
-  Future<Result<Address>> getUserAddress();
-
-  Future<Result<Address>> addAddress({
-    required String country,
-    required String city,
-  });
-
-  Future<Result<Address>> updateAddress({
-    required String addressId,
-    String? country,
-    String? city,
-  });
-
-  Future<Result<void>> deleteAddress(String addressId);
-
   Future<Result<String>> uploadProfilePhoto(String filePath);
 }


### PR DESCRIPTION
This commit updates the API endpoint constants to distinguish between the "Forgot Password" flow and a general "Reset Password" flow.

- The existing endpoint for resetting a password via the forgot password flow has been renamed from `resetPassword` to `resetForgotPassword`.
- A new endpoint, `resetPassword`, has been added for the general authenticated user password reset functionality at `/auth/reset-password`.
- The remote data source implementation has been updated to use the new `resetForgotPassword` endpoint.
