### PR TITLE
Fix fav

### DIFF
--- a/apps/customer/lib/data/datasource/remote/favorites_remote_datasource.dart
+++ b/apps/customer/lib/data/datasource/remote/favorites_remote_datasource.dart
@@ -1,6 +1,7 @@
+import 'package:dio/dio.dart';
+
 import '../../core/api/api_client.dart';
 import '../../core/api/api_endpoints.dart';
-import '../../mappers/favorite_mapper.dart';
 import '../../models/common/paginated_response.dart';
 import '../../models/product_model.dart';
 import '../../models/request/favorite_product_request.dart';
@@ -8,10 +9,6 @@ import '../../models/request/favorite_store_request.dart';
 import '../../models/store_model.dart';
 
 abstract class FavoritesRemoteDataSource {
-  Future<List<String>> getFavoriteProductIds();
-
-  Future<List<String>> getFavoriteStoreIds();
-
   Future<void> toggleProductFavorite({required String productId});
 
   Future<void> toggleStoreFavorite({required String storeId});
@@ -27,23 +24,11 @@ class FavoritesRemoteDataSourceImpl implements FavoritesRemoteDataSource {
   FavoritesRemoteDataSourceImpl(this._httpClient);
 
   @override
-  Future<List<String>> getFavoriteProductIds() async {
-    final response = await _httpClient.get(ApiEndpoints.favoriteProducts);
-    return FavoriteMapper.toProductIdListFromJson(response.data);
-  }
-
-  @override
-  Future<List<String>> getFavoriteStoreIds() async {
-    final response = await _httpClient.get(ApiEndpoints.favoriteStores);
-    return FavoriteMapper.toStoreIdListFromJson(response.data);
-  }
-
-  @override
   Future<void> toggleProductFavorite({required String productId}) async {
-    final request = FavoriteProductToggleRequest(productId: productId);
     await _httpClient.post(
       ApiEndpoints.favoriteProductToggle(productId),
-      data: request.toJson(),
+      data: FavoriteProductToggleRequest(productId: productId).toJson(),
+      options: Options(responseType: ResponseType.plain),
     );
   }
 

--- a/apps/customer/lib/data/mappers/store_mapper.dart
+++ b/apps/customer/lib/data/mappers/store_mapper.dart
@@ -22,22 +22,24 @@ extension StoreModelMapper on StoreModel {
     categories: categories?.map((e) => e.toEntity()).toList() ?? [],
     reviews: reviews?.map((e) => e.toEntity()).toList() ?? [],
     isActive: isActive ?? false,
+    isFavorite: isFavorite ?? false,
   );
 }
 
 extension StoreItemMapper on StoreTopRatingModel {
   Store toEntity() => Store(
-        id: id,
-        name: title,
-        description: '',
-        coverImage: coverImageURL ?? "",
-        profileImage: "",
-        sale: maxDiscount?.toString(),
-        rating: 0.0,
-        address: Address(country: "", city: ""),
-        contactInfoList: [],
-        categories: [],
-        reviews: [],
-        isActive: true,
-      );
+    id: id,
+    name: title,
+    description: '',
+    coverImage: coverImageURL ?? "",
+    profileImage: "",
+    sale: maxDiscount?.toString(),
+    rating: 0.0,
+    address: Address(country: "", city: ""),
+    contactInfoList: [],
+    categories: [],
+    reviews: [],
+    isActive: true,
+    isFavorite: isFavorite,
+  );
 }

--- a/apps/customer/lib/data/mock/mock_data_generator.dart
+++ b/apps/customer/lib/data/mock/mock_data_generator.dart
@@ -164,6 +164,7 @@ class MockDataGenerator {
     ];
 
     return Store(
+      isFavorite: false,
       id: 'store_$index',
       name: storeNames[index % storeNames.length],
       description:

--- a/apps/customer/lib/data/models/store_model.dart
+++ b/apps/customer/lib/data/models/store_model.dart
@@ -3,6 +3,12 @@ import 'review_model.dart';
 import 'address_model.dart';
 import 'category_model.dart';
 import 'contact_info_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'review_model.dart';
+import 'address_model.dart';
+import 'category_model.dart';
+import 'contact_info_model.dart';
+
 part 'store_model.freezed.dart';
 part 'store_model.g.dart';
 
@@ -19,8 +25,9 @@ class StoreModel with _$StoreModel {
     required AddressModel? address,
     required List<ContactInfoModel>? contactInfoList,
     required List<CategoryModel>? categories,
-    @Default([]) List<ReviewModel> ?reviews,
+    @Default([]) List<ReviewModel>? reviews,
     @Default(true) bool? isActive,
+    @Default(false) bool? isFavorite,
   }) = _StoreModel;
 
   factory StoreModel.fromJson(Map<String, dynamic> json) =>
@@ -30,5 +37,6 @@ class StoreModel with _$StoreModel {
             ?.map((e) => ReviewModel.fromJson(e as Map<String, dynamic>))
             .toList() ??
             [],
+        'isFavorite': json['isFavorite'] ?? false,
       });
 }

--- a/apps/customer/lib/data/repositories/favorites_repository_impl.dart
+++ b/apps/customer/lib/data/repositories/favorites_repository_impl.dart
@@ -21,83 +21,14 @@ class FavoritesRepositoryImpl implements FavoritesRepository {
   });
 
   @override
-  Future<Result<List<String>>> getFavoriteProductIds() async {
-    return RepositoryCallHandler.call<List<String>>(
-      () => remoteDataSource.getFavoriteProductIds(),
-    );
-  }
-
-  @override
-  Future<Result<List<String>>> getFavoriteStoreIds() async {
-    return RepositoryCallHandler.call<List<String>>(
-      () => remoteDataSource.getFavoriteStoreIds(),
-    );
-  }
-
-  @override
   Future<void> toggleProductFavorite(String productId) async {
-    RepositoryCallHandler.call<void>(
-          () async {
-            await remoteDataSource.toggleProductFavorite(productId: productId);
-      },
-    );
+    await remoteDataSource.toggleProductFavorite(productId: productId);
   }
+
 
   @override
   Future<void> toggleStoreFavorite(String storeId) async {
     await remoteDataSource.toggleStoreFavorite(storeId: storeId);
-  }
-
-  @override
-  Future<Result<bool>> isProductFavorite(String productId) async {
-    return RepositoryCallHandler.call<bool>(
-      () async {
-        final favoriteIds = await remoteDataSource.getFavoriteProductIds();
-        return favoriteIds.contains(productId);
-      },
-    );
-  }
-
-  @override
-  Future<Result<bool>> isStoreFavorite(String storeId) async {
-    return RepositoryCallHandler.call<bool>(
-      () async {
-        final favoriteIds = await remoteDataSource.getFavoriteStoreIds();
-        return favoriteIds.contains(storeId);
-      },
-    );
-  }
-
-  @override
-  Future<void> addProductToFavorites(String productId) async {
-    final favoriteIds = await remoteDataSource.getFavoriteProductIds();
-    if (!favoriteIds.contains(productId)) {
-      await remoteDataSource.toggleProductFavorite(productId: productId);
-    }
-  }
-
-  @override
-  Future<void> removeProductFromFavorites(String productId) async {
-    final favoriteIds = await remoteDataSource.getFavoriteProductIds();
-    if (favoriteIds.contains(productId)) {
-      await remoteDataSource.toggleProductFavorite(productId: productId);
-    }
-  }
-
-  @override
-  Future<void> addStoreToFavorites(String storeId) async {
-    final favoriteIds = await remoteDataSource.getFavoriteStoreIds();
-    if (!favoriteIds.contains(storeId)) {
-      await remoteDataSource.toggleStoreFavorite(storeId: storeId);
-    }
-  }
-
-  @override
-  Future<void> removeStoreFromFavorites(String storeId) async {
-    final favoriteIds = await remoteDataSource.getFavoriteStoreIds();
-    if (favoriteIds.contains(storeId)) {
-      await remoteDataSource.toggleStoreFavorite(storeId: storeId);
-    }
   }
 
   @override

--- a/apps/customer/lib/data/repositories/product_repository_impl.dart
+++ b/apps/customer/lib/data/repositories/product_repository_impl.dart
@@ -174,7 +174,6 @@ class ProductRepositoryImpl implements ProductRepository {
         page: page - 1,
         pageSize: limit,
       );
-      // print('product list: repo impl(1) -> ${paginatedResponse.data.map((model) => model.toEntity()).toList()[0].images}');
       print('product list: repo impl(2)-> ${paginatedResponse}');
       return paginatedResponse.data.map((model) => model.toEntity()).toList();
     });
@@ -197,35 +196,6 @@ class ProductRepositoryImpl implements ProductRepository {
       ),
     );
   }
-
-  @override
-  Future<Result<List<Product>>> getFavoriteProducts() async {
-    return RepositoryCallHandler.call<List<Product>>(() async {
-      final productIds = await _favoritesRemoteDataSource.getFavoriteProductIds();
-
-      final products = <Product>[];
-      for (final productId in productIds) {
-        try {
-          final model = await _remoteDataSource.getProductById(productId);
-          products.add(model.toEntity());
-        } catch (e) {
-          continue;
-        }
-      }
-
-      return products;
-    });
-  }
-
-  @override
-  Future<Result<bool>> isFavorite(String productId) async {
-    return RepositoryCallHandler.call<bool>(() async {
-      final favoriteIds = await _favoritesRemoteDataSource.getFavoriteProductIds();
-      return favoriteIds.contains(productId);
-    });
-  }
-
-
   PaginatedData<Product> _mapToPaginatedData(
       PaginatedResponse<ProductModel> response,
       ) {
@@ -269,5 +239,4 @@ class ProductRepositoryImpl implements ProductRepository {
       return _mapToPaginatedData(paginatedResponse);
     });
   }
-
 }

--- a/apps/customer/lib/data/repositories/store_repository_impl.dart
+++ b/apps/customer/lib/data/repositories/store_repository_impl.dart
@@ -116,37 +116,6 @@ class StoreRepositoryImpl implements StoreRepository {
   }
 
   @override
-  Future<Result<List<Store>>> getFavoriteStores() async {
-    return RepositoryCallHandler.call<List<Store>>(
-      () async {
-        final storeIds = await _favoritesRemoteDataSource.getFavoriteStoreIds();
-
-        final stores = <Store>[];
-        for (final storeId in storeIds) {
-          try {
-            final storeModel = await _remoteDataSource.getStoreById(storeId);
-            stores.add(storeModel.toEntity());
-          } catch (e) {
-            continue;
-          }
-        }
-        return stores;
-      },
-    );
-  }
-
-  @override
-  Future<Result<bool>> isFavorite(String storeId) async {
-    return RepositoryCallHandler.call<bool>(
-      () async {
-        final favoriteIds =
-            await _favoritesRemoteDataSource.getFavoriteStoreIds();
-        return favoriteIds.contains(storeId);
-      },
-    );
-  }
-
-  @override
   Future<Result<List<Review>>> getStoreReviews({
     required String storeId,
     int page = RepositoryConstants.defaultPage,

--- a/apps/customer/lib/di/modules/bloc_module.dart
+++ b/apps/customer/lib/di/modules/bloc_module.dart
@@ -24,7 +24,7 @@ class BlocModule {
     sl.registerFactory(() => HomeTopStoresCubit(sl()));
     sl.registerFactory(() => HomeSpecialOffersCubit(sl()));
     sl.registerFactory(() => NotificationCubit(sl()));
-    sl.registerFactory(() => ProductDetailsCubit(sl(), sl()));
+    sl.registerFactory(() => ProductDetailsCubit(sl(), sl(), sl()));
     sl.registerFactory(() => AccountCubit(sl()));
   }
 }

--- a/apps/customer/lib/domain/entities/store.dart
+++ b/apps/customer/lib/domain/entities/store.dart
@@ -16,6 +16,7 @@ class Store {
   final List<ContactInfo> contactInfoList;
   final List<Category> categories;
   final bool isActive;
+  final bool isFavorite;
 
   const Store({
     required this.id,
@@ -30,6 +31,7 @@ class Store {
     required this.categories,
     this.reviews = const [],
     this.isActive = true,
+    required this.isFavorite,
   });
 
   bool get hasSale => sale != null && sale!.isNotEmpty;
@@ -46,6 +48,7 @@ class Store {
     List<ContactInfo>? contactInfoList,
     List<Category>? categories,
     bool? isActive,
+    bool? isFavorite,
   }) {
     return Store(
       id: id ?? this.id,
@@ -59,6 +62,7 @@ class Store {
       categories: categories ?? this.categories,
       contactInfoList: contactInfoList ?? this.contactInfoList,
       isActive: isActive ?? this.isActive,
+      isFavorite: isFavorite ?? this.isFavorite,
     );
   }
 }

--- a/apps/customer/lib/domain/repositories/favorites_repository.dart
+++ b/apps/customer/lib/domain/repositories/favorites_repository.dart
@@ -3,26 +3,9 @@ import '../entities/product.dart';
 import '../entities/store.dart';
 
 abstract class FavoritesRepository {
-  Future<Result<List<String>>> getFavoriteProductIds();
-
-  Future<Result<List<String>>> getFavoriteStoreIds();
-
   Future<void> toggleProductFavorite(String productId);
 
   Future<void> toggleStoreFavorite(String storeId);
-
-  Future<Result<bool>> isProductFavorite(String productId);
-
-  Future<Result<bool>> isStoreFavorite(String storeId);
-
-  Future<void> addProductToFavorites(String productId);
-
-  Future<void> removeProductFromFavorites(String productId);
-
-  Future<void> addStoreToFavorites(String storeId);
-
-  Future<void> removeStoreFromFavorites(String storeId);
-
   Future<Result<List<Product>>> getFavoriteProductsFull();
 
   Future<Result<List<Store>>> getFavoriteStoresFull();

--- a/apps/customer/lib/domain/repositories/product_repository.dart
+++ b/apps/customer/lib/domain/repositories/product_repository.dart
@@ -58,10 +58,6 @@ abstract class ProductRepository {
 
   Future<Result<void>> toggleFavoriteProduct(String productId);
 
-  Future<Result<List<Product>>> getFavoriteProducts();
-
-  Future<Result<bool>> isFavorite(String productId);
-
   Future<Result<PaginatedData<Product>>> getThriftProducts({
     String? categoryId,
     int page = 1,

--- a/apps/customer/lib/domain/repositories/store_repository.dart
+++ b/apps/customer/lib/domain/repositories/store_repository.dart
@@ -32,10 +32,6 @@ abstract class StoreRepository {
 
   Future<Result<void>> toggleFavoriteStore(String storeId);
 
-  Future<Result<List<Store>>> getFavoriteStores();
-
-  Future<Result<bool>> isFavorite(String storeId);
-
   Future<Result<List<Review>>> getStoreReviews({
     required String storeId,
     int page = 1,

--- a/apps/customer/lib/presentation/cubits/favorites/cubit/favorites_cubit.dart
+++ b/apps/customer/lib/presentation/cubits/favorites/cubit/favorites_cubit.dart
@@ -1,164 +1,78 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import '../../../../../domain/repositories/favorites_repository.dart';
 import '../../../../domain/entities/product.dart';
 import '../../../../domain/entities/store.dart';
+import '../../../../domain/repositories/favorites_repository.dart';
 import 'favorites_state.dart';
+
+enum FavoriteType { product, store }
 
 class FavoritesCubit extends Cubit<FavoritesState> {
   final FavoritesRepository _favoritesRepository;
 
-  FavoritesCubit(this._favoritesRepository) : super(const FavoritesInitial());
+  FavoritesCubit(this._favoritesRepository) : super(const FavoritesInitial()) {
+    _loadInitialFavorites();
+  }
 
-  Future<void> loadFavorites() async {
-    emit(FavoritesLoading(
-      productIds: state.productIds,
-      storeIds: state.storeIds,
-      favoriteProducts: state.favoriteProducts,
-      favoriteStores: state.favoriteStores,
-    ));
-
+  Future<void> _loadInitialFavorites() async {
     try {
-      final productIdsResult =
-          await _favoritesRepository.getFavoriteProductIds();
-      final storeIdsResult = await _favoritesRepository.getFavoriteStoreIds();
+      emit(const FavoritesInitial());
 
-      final productsResult =
-          await _favoritesRepository.getFavoriteProductsFull();
+      final productsResult = await _favoritesRepository.getFavoriteProductsFull();
       final storesResult = await _favoritesRepository.getFavoriteStoresFull();
 
-      debugPrint("fav IDs: ${productIdsResult.data}, ${storeIdsResult.data}");
-      debugPrint(
-          "fav full: ${productsResult.data?.length ?? 0} products, ${storesResult.data?.length ?? 0} stores");
+      final products = productsResult.isSuccess ? productsResult.data : <Product>[];
+      final stores = storesResult.isSuccess ? storesResult.data : <Store>[];
 
       emit(FavoritesLoaded(
-        productIds: productIdsResult.data.toSet(),
-        storeIds: storeIdsResult.data.toSet(),
-        favoriteProducts: productsResult.isSuccess
-            ? (productsResult.data as List<Product>?) ?? <Product>[]
-            : null,
-        favoriteStores: storesResult.isSuccess
-            ? (storesResult.data as List<Store>?) ?? <Store>[]
-            : null,
+        favoriteProducts: products,
+        favoriteStores: stores,
+        favoriteProductIds: products.map((e) => e.id).toSet(),
+        favoriteStoreIds: stores.map((e) => e.id).toSet(),
       ));
-    } catch (e) {
-      emit(FavoritesError(
-        message: e.toString(),
-        productIds: state.productIds,
-        storeIds: state.storeIds,
-        favoriteProducts: state.favoriteProducts,
-        favoriteStores: state.favoriteStores,
-      ));
+    } catch (_) {
+      emit(const FavoritesActionFailure('Failed to load favorites'));
     }
   }
 
-  Future<bool> toggleProductFavorite(String productId) async {
-    emit(const FavoritesLoading());
+  Future<void> toggleFavorite(String id, FavoriteType type) async {
+    if (state is! FavoritesLoaded) return;
 
-    try {
-      await _favoritesRepository.toggleProductFavorite(productId);
-      debugPrint('Succeded to toggle product favorite:}');
-      emit(FavoritesLoaded(productIds:Set(),storeIds: Set()));
+    final current = state as FavoritesLoaded;
 
-      return true;
-    } catch (e) {
+    if (type == FavoriteType.product) {
+      final isFavorite = current.favoriteProductIds.contains(id);
 
-      debugPrint('Failed to toggle product favorite: ${e.toString()}');
-      emit(FavoritesError(
-        message: 'Failed to update favorite: ${e.toString()}',
-        productIds: Set(),
-        storeIds:Set(),
-        favoriteProducts:[],
-        favoriteStores:[],
-        loadingProductIds: Set(),
-        loadingStoreIds: Set(),
+      final updatedProducts = isFavorite
+          ? current.favoriteProducts.where((p) => p.id != id).toList()
+          : current.favoriteProducts;
+
+      emit(current.copyWith(
+        favoriteProducts: updatedProducts,
+        favoriteProductIds: updatedProducts.map((e) => e.id).toSet(),
       ));
-      return false;
-    }
-  }
 
-  Future<bool> toggleStoreFavorite(String storeId) async {
-    if (state is! FavoritesLoaded) return false;
-
-    final currentState = state as FavoritesLoaded;
-    
-    // Prevent duplicate requests for the same store
-    if (currentState.loadingStoreIds.contains(storeId)) {
-      debugPrint('Toggle already in progress for store: $storeId');
-      return false;
-    }
-
-    // Step 1: Add to loading set (show loader in UI)
-    final loadingIds = Set<String>.from(currentState.loadingStoreIds)..add(storeId);
-    emit(currentState.copyWith(loadingStoreIds: loadingIds));
-
-    try {
-      // Step 2: Make API call and wait for response
-      await _favoritesRepository.toggleStoreFavorite(storeId);
-      
-      // Step 3: On success, toggle the favorite state
-      final isFavorite = currentState.storeIds.contains(storeId);
-      final updatedIds = Set<String>.from(currentState.storeIds);
-      
-      if (isFavorite) {
-        updatedIds.remove(storeId);
-        debugPrint('Store $storeId removed from favorites');
-      } else {
-        updatedIds.add(storeId);
-        debugPrint('Store $storeId added to favorites');
+      try {
+        await _favoritesRepository.toggleProductFavorite(id);
+      } catch (_) {
+        emit(current);
       }
+    } else if (type == FavoriteType.store) {
+      final isFavorite = current.favoriteStoreIds.contains(id);
 
-      // Remove from loading and update storeIds
-      final finalLoadingIds = Set<String>.from(loadingIds)..remove(storeId);
-      emit(currentState.copyWith(
-        storeIds: updatedIds,
-        loadingStoreIds: finalLoadingIds,
+      final updatedStores = isFavorite
+          ? current.favoriteStores.where((s) => s.id != id).toList()
+          : current.favoriteStores;
+
+      emit(current.copyWith(
+        favoriteStores: updatedStores,
+        favoriteStoreIds: updatedStores.map((e) => e.id).toSet(),
       ));
 
-      return true;
-    } catch (e) {
-      // Step 4: On error, remove from loading but keep original state
-      debugPrint('Failed to toggle store favorite: ${e.toString()}');
-      
-      final finalLoadingIds = Set<String>.from(loadingIds)..remove(storeId);
-      emit(currentState.copyWith(loadingStoreIds: finalLoadingIds));
-      
-      // Emit error state briefly
-      emit(FavoritesError(
-        message: 'Failed to update favorite: ${e.toString()}',
-        productIds: currentState.productIds,
-        storeIds: currentState.storeIds,
-        favoriteProducts: currentState.favoriteProducts,
-        favoriteStores: currentState.favoriteStores,
-        loadingProductIds: currentState.loadingProductIds,
-        loadingStoreIds: finalLoadingIds,
-      ));
-      
-      // Restore to loaded state
-      emit(currentState.copyWith(loadingStoreIds: finalLoadingIds));
-      
-      return false;
+      try {
+        await _favoritesRepository.toggleStoreFavorite(id);
+      } catch (_) {
+        emit(current);
+      }
     }
   }
-
-  bool isProductFavorite(String productId) {
-    return state.productIds.contains(productId);
-  }
-
-  bool isStoreFavorite(String storeId) {
-    return state.storeIds.contains(storeId);
-  }
-
-  bool isProductLoading(String productId) {
-    return state.loadingProductIds.contains(productId);
-  }
-
-  bool isStoreLoading(String storeId) {
-    return state.loadingStoreIds.contains(storeId);
-  }
-
-  List<Product> get favoriteProductsList => state.favoriteProducts ?? [];
-
-  List<Store> get favoriteStoresList => state.favoriteStores ?? [];
 }

--- a/apps/customer/lib/presentation/cubits/favorites/cubit/favorites_state.dart
+++ b/apps/customer/lib/presentation/cubits/favorites/cubit/favorites_state.dart
@@ -1,89 +1,64 @@
 import 'package:equatable/equatable.dart';
-import 'package:sellio_mobile/domain/entities/product.dart';
-import 'package:sellio_mobile/domain/entities/store.dart';
+import '../../../../domain/entities/product.dart';
+import '../../../../domain/entities/store.dart';
 
 abstract class FavoritesState extends Equatable {
-  final Set<String> productIds;
-  final Set<String> storeIds;
-  final List<Product>? favoriteProducts;
-  final List<Store>? favoriteStores;
-  /// Set of product IDs that are currently being toggled (loading state)
-  final Set<String> loadingProductIds;
-  /// Set of store IDs that are currently being toggled (loading state)
-  final Set<String> loadingStoreIds;
-
-  const FavoritesState({
-    this.productIds = const {},
-    this.storeIds = const {},
-    this.favoriteProducts,
-    this.favoriteStores,
-    this.loadingProductIds = const {},
-    this.loadingStoreIds = const {},
-  });
+  const FavoritesState();
 
   @override
-  List<Object?> get props =>
-      [productIds, storeIds, favoriteProducts, favoriteStores, loadingProductIds, loadingStoreIds];
+  List<Object?> get props => [];
 }
 
 class FavoritesInitial extends FavoritesState {
   const FavoritesInitial();
 }
 
-class FavoritesLoading extends FavoritesState {
-  const FavoritesLoading({
-    super.productIds,
-    super.storeIds,
-    super.favoriteProducts,
-    super.favoriteStores,
-    super.loadingProductIds,
-    super.loadingStoreIds,
-  });
-}
-
 class FavoritesLoaded extends FavoritesState {
+  final Set<String> favoriteProductIds;
+  final Set<String> favoriteStoreIds;
+
+  final List<Product> favoriteProducts;
+  final List<Store> favoriteStores;
+
   const FavoritesLoaded({
-    required super.productIds,
-    required super.storeIds,
-    super.favoriteProducts,
-    super.favoriteStores,
-    super.loadingProductIds,
-    super.loadingStoreIds,
+    required this.favoriteProductIds,
+    required this.favoriteStoreIds,
+    required this.favoriteProducts,
+    required this.favoriteStores,
   });
 
   FavoritesLoaded copyWith({
-    Set<String>? productIds,
-    Set<String>? storeIds,
+    Set<String>? favoriteProductIds,
+    Set<String>? favoriteStoreIds,
     List<Product>? favoriteProducts,
     List<Store>? favoriteStores,
-    Set<String>? loadingProductIds,
-    Set<String>? loadingStoreIds,
   }) {
     return FavoritesLoaded(
-      productIds: productIds ?? this.productIds,
-      storeIds: storeIds ?? this.storeIds,
-      favoriteProducts: favoriteProducts ?? this.favoriteProducts,
-      favoriteStores: favoriteStores ?? this.favoriteStores,
-      loadingProductIds: loadingProductIds ?? this.loadingProductIds,
-      loadingStoreIds: loadingStoreIds ?? this.loadingStoreIds,
+      favoriteProductIds:
+      favoriteProductIds ?? this.favoriteProductIds,
+      favoriteStoreIds:
+      favoriteStoreIds ?? this.favoriteStoreIds,
+      favoriteProducts:
+      favoriteProducts ?? this.favoriteProducts,
+      favoriteStores:
+      favoriteStores ?? this.favoriteStores,
     );
   }
-}
-
-class FavoritesError extends FavoritesState {
-  final String message;
-
-  const FavoritesError({
-    required this.message,
-    super.productIds,
-    super.storeIds,
-    super.favoriteProducts,
-    super.favoriteStores,
-    super.loadingProductIds,
-    super.loadingStoreIds,
-  });
 
   @override
-  List<Object?> get props =>
-      [message, productIds, storeIds, favoriteProducts, favoriteStores, loadingProductIds, loadingStoreIds];
+  List<Object?> get props => [
+    favoriteProductIds,
+    favoriteStoreIds,
+    favoriteProducts,
+    favoriteStores,
+  ];
+}
+
+class FavoritesActionFailure extends FavoritesState {
+  final String message;
+
+  const FavoritesActionFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
 }

--- a/apps/customer/lib/presentation/screens/account/myFav/myFavorites.dart
+++ b/apps/customer/lib/presentation/screens/account/myFav/myFavorites.dart
@@ -1,14 +1,13 @@
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
-import 'package:sellio_mobile/presentation/cubits/favorites/cubit/favorites_cubit.dart';
-import 'package:sellio_mobile/presentation/cubits/favorites/cubit/favorites_state.dart';
-import 'package:sellio_mobile/presentation/screens/account/myFav/widgets/empty_favorites_state.dart';
-
-import '../../../../core/utils/snackbar_helper.dart';
-import 'widgets/products_grid_section.dart';
+import '../../../../core/localization/l10n/localization_service.dart';
+import '../../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../../cubits/favorites/cubit/favorites_state.dart';
 import 'widgets/stores_section.dart';
+import 'widgets/products_grid_section.dart';
+import 'widgets/empty_favorites_state.dart';
+import '../../../../core/utils/snackbar_helper.dart';
 
 class FavoritesScreen extends StatefulWidget {
   const FavoritesScreen({super.key});
@@ -21,20 +20,9 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   int _selectedTabIndex = 0;
 
   List<TabInfo> _getTabs(BuildContext context) => [
-        TabInfo(context.local.products, AppImages.product),
-        TabInfo(context.local.stores, AppImages.store),
-      ];
-
-  @override
-  void initState() {
-    super.initState();
-    // Load favorites when screen opens
-    _loadFavorites();
-  }
-
-  void _loadFavorites() {
-    context.read<FavoritesCubit>().loadFavorites();
-  }
+    TabInfo(context.local.products, AppImages.product),
+    TabInfo(context.local.stores, AppImages.store),
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -44,8 +32,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
     return BlocListener<FavoritesCubit, FavoritesState>(
       listener: (context, state) {
-        // listen for error
-        if (state is FavoritesError) {
+        if (state is FavoritesActionFailure) {
           SnackBarHelper.showError(context, state.message);
         }
       },
@@ -55,87 +42,56 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
           title: context.local.favorites,
           showBackButton: true,
         ),
-        body: RefreshIndicator(
-          onRefresh: () async {
-            _loadFavorites();
-          },
-          child: SafeArea(
-            child: BlocBuilder<FavoritesCubit, FavoritesState>(
-              builder: (context, state) {
-                return CustomScrollView(
-                  slivers: [
-                    // Category Tabs
-                    SliverToBoxAdapter(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 8,
-                        ),
-                        child: Row(
-                          children: List.generate(tabs.length, (index) {
-                            final isSelected = _selectedTabIndex == index;
-                            final tab = tabs[index];
+        body: SafeArea(
+          child: BlocBuilder<FavoritesCubit, FavoritesState>(
+            builder: (context, state) {
+              if (state is FavoritesInitial) {
+                return const Center(child: CircularProgressIndicator());
+              }
 
-                            return Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 6),
-                              child: SellioChip(
-                                label: tab.label,
-                                assetIcon: tab.iconAsset,
-                                selected: isSelected,
-                                onTap: () =>
-                                    setState(() => _selectedTabIndex = index),
-                              ),
-                            );
-                          }),
-                        ),
+              if (state is! FavoritesLoaded) {
+                return const EmptyFavoritesWidget();
+              }
+
+              return CustomScrollView(
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 8,
+                      ),
+                      child: Row(
+                        children: List.generate(tabs.length, (index) {
+                          final isSelected = _selectedTabIndex == index;
+                          final tab = tabs[index];
+
+                          return Padding(
+                            padding:
+                            const EdgeInsets.symmetric(horizontal: 6),
+                            child: SellioChip(
+                              label: tab.label,
+                              assetIcon: tab.iconAsset,
+                              selected: isSelected,
+                              onTap: () =>
+                                  setState(() => _selectedTabIndex = index),
+                            ),
+                          );
+                        }),
                       ),
                     ),
+                  ),
 
-                    // Loading state
-                    if (state is FavoritesLoading)
-                      const SliverFillRemaining(
-                        child: Center(
-                          child: CircularProgressIndicator(),
-                        ),
-                      )
-
-                    // Products or Stores Tab
-                    else if (state is FavoritesLoaded)
-                      _selectedTabIndex == 0
-                          ? ProductsGridSection(
-                              products: state.favoriteProducts ?? [],
-                              onToggleFavorite: (productId) async =>
-                                  await context
-                                      .read<FavoritesCubit>()
-                                      .toggleProductFavorite(productId),
-                            )
-                          : StoresSection(
-                              stores: state.favoriteStores ?? [],
-                              onToggleFavorite: (storeId) => context
-                                  .read<FavoritesCubit>()
-                                  .toggleStoreFavorite(storeId),
-                            )
-
-                    // Error state
-                    else if (state is FavoritesError)
-                      const SliverFillRemaining(
-                        child: Center(
-                          child: EmptyFavoritesWidget(),
-                        ),
-                      )
-
-                    // Initial state
-                    else
-                      const SliverFillRemaining(
-                        child: Center(
-                          child: CircularProgressIndicator(),
-                        ),
-                      ),
-                  ],
-                );
-              },
-            ),
+                  _selectedTabIndex == 0
+                      ? ProductsGridSection(
+                    products: state.favoriteProducts,
+                  )
+                      : StoresSection(
+                    stores: state.favoriteStores,
+                  ),
+                ],
+              );
+            },
           ),
         ),
       ),
@@ -146,6 +102,5 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 class TabInfo {
   final String label;
   final String iconAsset;
-
   const TabInfo(this.label, this.iconAsset);
 }

--- a/apps/customer/lib/presentation/screens/account/myFav/widgets/products_grid_section.dart
+++ b/apps/customer/lib/presentation/screens/account/myFav/widgets/products_grid_section.dart
@@ -1,22 +1,16 @@
-import 'package:design_system/design_system.dart';
-import 'package:flutter/material.dart';
+import 'package:design_system/widgets/cards/sellio_product_vertical_card.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:sellio_mobile/core/error/result.dart';
-import 'package:sellio_mobile/domain/entities/product.dart';
-import 'package:sellio_mobile/domain/repositories/product_repository.dart';
-import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_cubit.dart';
-import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_state.dart';
-
+import '../../../../../domain/entities/product.dart';
+import '../../../../cubits/favorites/cubit/favorites_cubit.dart';
 import 'empty_favorites_state.dart';
 
 class ProductsGridSection extends StatelessWidget {
   final List<Product> products;
-  final Future<bool> Function(String) onToggleFavorite;
 
   const ProductsGridSection({
     super.key,
     required this.products,
-    required this.onToggleFavorite,
   });
 
   @override
@@ -29,80 +23,35 @@ class ProductsGridSection extends StatelessWidget {
 
     return SliverPadding(
       padding: const EdgeInsets.all(16),
-      sliver: FutureBuilder<Result<List<Product>>>(
-        future: context.read<ProductRepository>().getFavoriteProducts(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const SliverToBoxAdapter(
-              child: Center(
-                child: Padding(
-                  padding: EdgeInsets.all(48.0),
-                  child: CircularProgressIndicator(),
-                ),
-              ),
+      sliver: SliverGrid(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 0.68,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+        ),
+        delegate: SliverChildBuilderDelegate(
+              (context, index) {
+            final product = products[index];
+
+            return SellioProductVerticalCard(
+              productId: product.id,
+              imageUrl:
+              product.images.isNotEmpty ? product.images.first : '',
+              title: product.title,
+              price:
+              '${product.currency}${product.price.toStringAsFixed(2)}',
+              isFavorite: true,
+              onFavoriteToggle: () async {
+                context
+                    .read<FavoritesCubit>()
+                    .toggleFavorite(product.id, FavoriteType.product);
+                return;
+              },
             );
-          }
-
-          if (snapshot.hasError || !snapshot.hasData) {
-            return const SliverToBoxAdapter(
-              child: EmptyFavoritesWidget(),
-            );
-          }
-
-          final result = snapshot.data!;
-
-          if (result is! Success<List<Product>>) {
-            return const SliverToBoxAdapter(
-              child: EmptyFavoritesWidget(),
-            );
-          }
-
-          final products = result.data;
-
-          if (products.isEmpty) {
-            return const SliverToBoxAdapter(
-              child: EmptyFavoritesWidget(),
-            );
-          }
-
-          return BlocBuilder<CartCubit, CartState>(
-            builder: (context, cartState) {
-              return SliverGrid(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  childAspectRatio: 0.68,
-                  crossAxisSpacing: 12,
-                  mainAxisSpacing: 12,
-                ),
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final product = products[index];
-
-                    return SellioProductVerticalCard(
-                      productId: product.id,
-                      imageUrl:
-                          product.images.isNotEmpty ? product.images.first : '',
-                      title: product.title,
-                      price:
-                          '${product.currency}${product.price.toStringAsFixed(2)}',
-                      isFavorite: true,
-                      onFavoriteToggle: () async {
-                        // Pessimistic update: wait for API response before updating UI
-                        final success = await onToggleFavorite(product.id);
-                        return success;
-                      },
-                      onTap: () {
-                        // Navigate to product details
-                        // Example: context.push('/product/${product.id}');
-                      },
-                    );
-                  },
-                  childCount: products.length,
-                ),
-              );
-            },
-          );
-        },
+          },
+          childCount: products.length,
+        ),
       ),
     );
   }

--- a/apps/customer/lib/presentation/screens/account/myFav/widgets/stores_section.dart
+++ b/apps/customer/lib/presentation/screens/account/myFav/widgets/stores_section.dart
@@ -1,20 +1,16 @@
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:sellio_mobile/core/error/result.dart';
 import 'package:sellio_mobile/domain/entities/store.dart';
-import 'package:sellio_mobile/domain/repositories/store_repository.dart';
-
+import '../../../../cubits/favorites/cubit/favorites_cubit.dart';
 import 'empty_favorites_state.dart';
 
 class StoresSection extends StatelessWidget {
   final List<Store> stores;
-  final void Function(String) onToggleFavorite;
 
   const StoresSection({
     super.key,
     required this.stores,
-    required this.onToggleFavorite,
   });
 
   @override
@@ -26,56 +22,26 @@ class StoresSection extends StatelessWidget {
     }
 
     return SliverToBoxAdapter(
-      child: FutureBuilder<Result<List<Store>>>(
-        future: context.read<StoreRepository>().getFavoriteStores(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(
-              child: Padding(
-                padding: EdgeInsets.all(48.0),
-                child: CircularProgressIndicator(),
-              ),
-            );
-          }
+      child: ListView.separated(
+        padding: const EdgeInsets.only(top: 16),
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: stores.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (context, index) {
+          final store = stores[index];
 
-          if (snapshot.hasError || !snapshot.hasData) {
-            return const EmptyFavoritesWidget();
-          }
-
-          final result = snapshot.data!;
-
-          if (result is! Success<List<Store>>) {
-            return const EmptyFavoritesWidget();
-          }
-
-          final stores = result.data;
-
-          if (stores.isEmpty) {
-            return const EmptyFavoritesWidget();
-          }
-
-          return Padding(
-            padding: const EdgeInsets.only(top: 16),
-            child: ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: stores.length,
-              itemBuilder: (context, index) {
-                final store = stores[index];
-
-                return SellioStoreCard(
-                  imageUrl: store.coverImage,
-                  title: store.name,
-                  discountText: store.sale,
-                  isFavorite: true,
-                  onLikePressed: () => onToggleFavorite(store.id),
-                  onCardPressed: () {
-                    // Navigate to store details
-                    // Example: context.push('/store/${store.id}');
-                  },
-                );
-              },
-            ),
+          return SellioStoreCard(
+            imageUrl: store.coverImage,
+            title: store.name,
+            discountText: store.sale,
+            isFavorite: true,
+            onLikePressed: () {
+              context
+                  .read<FavoritesCubit>()
+                  .toggleFavorite(store.id, FavoriteType.store);
+            },
+            onCardPressed: () {},
           );
         },
       ),

--- a/apps/customer/lib/presentation/screens/home/home_screen.dart
+++ b/apps/customer/lib/presentation/screens/home/home_screen.dart
@@ -1,12 +1,11 @@
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
+import 'package:sellio_mobile/presentation/screens/home/sections/trending_products/trending_products_section.dart';
 import 'package:sellio_mobile/presentation/screens/home/utils/home_navigation.dart';
-
 import 'home_bloc_providers.dart';
 import 'sections/search/search_section.dart';
 import 'sections/special_offers/special_offers_section.dart';
 import 'sections/top_stores/top_stores_section.dart';
-import 'sections/trending_products/trending_products_section.dart';
 import 'utils/home_refresh_handler.dart';
 import 'widgets/home_app_bar.dart';
 

--- a/apps/customer/lib/presentation/screens/home/sections/top_stores/top_stores_section.dart
+++ b/apps/customer/lib/presentation/screens/home/sections/top_stores/top_stores_section.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import '../../../../cubits/favorites/cubit/favorites_cubit.dart';
 import '../../../../cubits/favorites/cubit/favorites_state.dart';
-import '../../utils/home_navigation.dart';
 import 'cubit/home_top_stores_cubit.dart';
 import 'cubit/home_top_stores_state.dart';
 import 'top_stores_list_shimmer.dart';
 import 'widgets/stores_list.dart';
+import '../../utils/home_navigation.dart';
 
 class TopStoresSection extends StatelessWidget {
   const TopStoresSection({super.key});
@@ -16,7 +15,6 @@ class TopStoresSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocConsumer<HomeTopStoresCubit, HomeTopStoresState>(
       listener: (context, state) {
-        // Handle side effects
         if (state is HomeTopStoresError) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -36,37 +34,37 @@ class TopStoresSection extends StatelessWidget {
       builder: (context, storesState) {
         if (storesState is HomeTopStoresLoading) {
           return const SliverToBoxAdapter(
-              child: Padding(
-                  padding: EdgeInsets.only(top: 24),
-                  child: TopStoresShimmer()));
+            child: Padding(
+              padding: EdgeInsets.only(top: 24),
+              child: TopStoresShimmer(),
+            ),
+          );
         }
 
         if (storesState is! HomeTopStoresLoaded || storesState.stores.isEmpty) {
           return const SliverToBoxAdapter(child: SizedBox.shrink());
         }
 
-        return BlocConsumer<FavoritesCubit, FavoritesState>(
-          listener: (context, favState) {
-            // Handle favorites side effects
-            if (favState is FavoritesError) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(favState.message),
-                  backgroundColor: Colors.red,
-                ),
-              );
-            }
-          },
+        return BlocBuilder<FavoritesCubit, FavoritesState>(
           builder: (context, favState) {
             return SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(0, 24, 0, 0),
                 child: StoresList(
                   stores: storesState.stores,
-                  favoriteStoreIds: favState.storeIds,
-                  onLikePressed: (storeId) {
-                    context.read<FavoritesCubit>().toggleStoreFavorite(storeId);
+
+                  isStoreFavorited: (store) {
+                    if (favState is FavoritesLoaded) {
+                      return favState.favoriteStoreIds.contains(store.id);
+                    }
+                    return store.isFavorite;
                   },
+
+                  onLikePressed: (store) async {
+                    context.read<FavoritesCubit>().toggleFavorite(store.id, FavoriteType.store);
+                  },
+
+                  // Store tap
                   onStorePressed: (store) {
                     navigateToStoreDetails(context, store.id);
                   },
@@ -76,20 +74,6 @@ class TopStoresSection extends StatelessWidget {
           },
         );
       },
-    );
-  }
-}
-
-class _LoadingWidget extends StatelessWidget {
-  const _LoadingWidget();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(
-      child: Padding(
-        padding: EdgeInsets.all(24.0),
-        child: CircularProgressIndicator(),
-      ),
     );
   }
 }

--- a/apps/customer/lib/presentation/screens/home/sections/top_stores/widgets/stores_list.dart
+++ b/apps/customer/lib/presentation/screens/home/sections/top_stores/widgets/stores_list.dart
@@ -1,23 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:design_system/design_system.dart';
-import 'package:design_system/design_system.dart';
-import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import 'package:sellio_mobile/domain/entities/store.dart';
-import 'package:design_system/design_system.dart';
+
+import '../../../../../../core/localization/l10n/localization_service.dart';
 
 class StoresList extends StatelessWidget {
   final List<Store> stores;
-  final Set<String> favoriteStoreIds;
-  final Function(String storeId) onLikePressed;
+  final Function(Store store) onLikePressed;
   final Function(Store store) onStorePressed;
+  final bool Function(Store store)? isStoreFavorited; // Optional callback
 
   const StoresList({
     super.key,
     required this.stores,
-    required this.favoriteStoreIds,
     required this.onLikePressed,
     required this.onStorePressed,
+    this.isStoreFavorited,
   });
 
   @override
@@ -26,10 +25,12 @@ class StoresList extends StatelessWidget {
       children: [
         SectionHeader(
           title: context.local.top_stores,
-          onTap: () {
-
-          },
-          trailing: SvgPicture.asset(AppImages.arrowRight, width: 20, height: 20, matchTextDirection: true),
+          trailing: SvgPicture.asset(
+            AppImages.arrowRight,
+            width: 20,
+            height: 20,
+            matchTextDirection: true,
+          ),
         ),
         ListView.builder(
           shrinkWrap: true,
@@ -37,14 +38,16 @@ class StoresList extends StatelessWidget {
           itemCount: stores.length,
           itemBuilder: (context, index) {
             final store = stores[index];
-            final isFavorite = favoriteStoreIds.contains(store.id);
+            final isFavorite = isStoreFavorited != null
+                ? isStoreFavorited!(store)
+                : store.isFavorite;
 
             return SellioStoreCard(
               imageUrl: store.coverImage,
               title: store.name,
               discountText: store.sale,
               isFavorite: isFavorite,
-              onLikePressed: () => onLikePressed(store.id),
+              onLikePressed: () => onLikePressed(store),
               onCardPressed: () => onStorePressed(store),
             );
           },

--- a/apps/customer/lib/presentation/screens/home/sections/trending_products/trending_products_section.dart
+++ b/apps/customer/lib/presentation/screens/home/sections/trending_products/trending_products_section.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'product_list_shimmer.dart';
-import '../../../../cubits/cart/cubit/cart_cubit.dart';
-import '../../../../cubits/cart/cubit/cart_state.dart';
-import '../../../../cubits/favorites/cubit/favorites_cubit.dart';
-import '../../../../cubits/favorites/cubit/favorites_state.dart';
 import 'cubit/home_trending_products_cubit.dart';
 import 'cubit/home_trending_products_state.dart';
 import 'widgets/products_list.dart';
@@ -36,51 +32,31 @@ class TrendingProductsSection extends StatelessWidget {
           );
         }
       },
-      builder: (context, productsState) {
-        if (productsState is HomeTrendingProductsLoading ||
-            productsState is HomeTrendingProductsSearching) {
-          return const SliverToBoxAdapter(
-            child: ProductsListShimmer(),
-          );
+      builder: (context, state) {
+        if (state is HomeTrendingProductsLoading ||
+            state is HomeTrendingProductsSearching) {
+          return const SliverToBoxAdapter(child: ProductsListShimmer());
         }
 
-        if (productsState is HomeTrendingProductsError) {
+        if (state is HomeTrendingProductsError) {
           return SliverToBoxAdapter(
             child: _ErrorWidget(
-              message: productsState.message,
-              onRetry: () {
-                context.read<HomeTrendingProductsCubit>().refreshProducts();
-              },
+              message: state.message,
+              onRetry: () =>
+                  context.read<HomeTrendingProductsCubit>().refreshProducts(),
             ),
           );
         }
 
-        if (productsState is! HomeTrendingProductsLoaded) {
+        if (state is! HomeTrendingProductsLoaded) {
           return const SliverToBoxAdapter(child: SizedBox.shrink());
         }
 
-        return BlocConsumer<FavoritesCubit, FavoritesState>(
-          listener: (context, favState) {
-            if (favState is FavoritesError) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(favState.message),
-                  backgroundColor: Colors.red,
-                ),
-              );
-            }
-          },
-          builder: (context, favState) {
-            return SliverToBoxAdapter(
-              child: ProductsList(
-                products: productsState.products,
-                searchQuery: productsState.searchQuery,
-                onFavorite: (productId) async => await context
-                    .read<FavoritesCubit>()
-                    .toggleProductFavorite(productId),
-              ),
-            );
-          },
+        return SliverToBoxAdapter(
+          child: ProductsList(
+            products: state.products,
+            searchQuery: state.searchQuery,
+          ),
         );
       },
     );
@@ -91,10 +67,7 @@ class _ErrorWidget extends StatelessWidget {
   final String message;
   final VoidCallback onRetry;
 
-  const _ErrorWidget({
-    required this.message,
-    required this.onRetry,
-  });
+  const _ErrorWidget({required this.message, required this.onRetry});
 
   @override
   Widget build(BuildContext context) {
@@ -107,12 +80,10 @@ class _ErrorWidget extends StatelessWidget {
             Text(
               message,
               textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: onRetry,
-              child: const Text('Retry'),
-            ),
+            ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
           ],
         ),
       ),

--- a/apps/customer/lib/presentation/screens/home/sections/trending_products/widgets/products_list.dart
+++ b/apps/customer/lib/presentation/screens/home/sections/trending_products/widgets/products_list.dart
@@ -1,21 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:design_system/design_system.dart';
 import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
-import 'package:sellio_mobile/presentation/screens/home/utils/home_navigation.dart';
+import '../../../../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../../../../cubits/favorites/cubit/favorites_state.dart';
 import '../models/product_summary_ui_model.dart';
 
 class ProductsList extends StatelessWidget {
   final List<ProductSummaryUIModel> products;
   final String? searchQuery;
-  final Future<bool> Function(String) onFavorite;
 
   const ProductsList({
     super.key,
     required this.products,
     this.searchQuery,
-    required this.onFavorite,
   });
 
   @override
@@ -25,78 +24,80 @@ class ProductsList extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
-          child: GestureDetector(
-            onTap: () => _navigateToMoreTrending(context),
-            child: SectionHeader(
-              title: searchQuery == null
-                  ? context.local.trending_products
-                  : context.local.search_results,
-              trailing: SvgPicture.asset(
-                AppImages.arrowRight,
-                width: 20,
-                height: 20,
-                matchTextDirection: true,
-              ),
+          child: SectionHeader(
+            title: searchQuery == null
+                ? context.local.trending_products
+                : context.local.search_results,
+            trailing: SvgPicture.asset(
+              AppImages.arrowRight,
+              width: 20,
+              height: 20,
             ),
           ),
         ),
-        products.isEmpty
-            ? _buildEmptyState(context)
-            : _buildProductsList(),
+        if (products.isEmpty)
+          SizedBox(
+            height: 272,
+            child: Center(
+              child: Text(
+                searchQuery == null
+                    ? context.local.no_products_available
+                    : context.local.no_products_found_for(
+                    searchQuery as Object,),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+          )
+        else
+          SizedBox(
+            height: 210,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              itemCount: products.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemBuilder: (context, index) {
+                final product = products[index];
+                return SizedBox(
+                  width: 160,
+                  child: _ProductItem(product: product),
+                );
+              },
+            ),
+          ),
       ],
     );
   }
+}
 
-  void _navigateToMoreTrending(BuildContext context) {
-    // Only navigate for trending products, not search results
-    if (searchQuery == null) {
-      context.push('/moreTrending');
-    }
-  }
+class _ProductItem extends StatelessWidget {
+  final ProductSummaryUIModel product;
 
-  Widget _buildEmptyState(BuildContext context) {
-    return SizedBox(
-      height: 272,
-      child: Center(
-        child: Text(
-          searchQuery == null
-              ? context.local.no_products_available
-              : context.local.no_products_found_for(searchQuery as Object),
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
-      ),
-    );
-  }
+  const _ProductItem({required this.product});
 
-  Widget _buildProductsList() {
-    return SizedBox(
-      height: 210,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        itemCount: products.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 12),
-        itemBuilder: (context, index) {
-          final product = products[index];
-          print('product list:${product.title}, ${product.imageUrl}');
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FavoritesCubit, FavoritesState>(
+      builder: (context, state) {
+        bool isFavorite = product.isFavorite;
 
-          return SizedBox(
-            width: 160,
-            child: SellioProductVerticalCard(
-              productId: product.id,
-              imageUrl: product.imageUrl,
-              title: product.title,
-              price: product.price,
-              isFavorite: product.isFavorite,
-              onFavoriteToggle: () async {
-                final success = await onFavorite(product.id);
-                return success;
-              },
-              onTap: () => navigateToProductDetails(context, product.id),
-            ),
-          );
-        },
-      ),
+        if (state is FavoritesLoaded) {
+          isFavorite = state.favoriteProductIds.contains(product.id);
+        }
+
+        return SellioProductVerticalCard(
+          key: ValueKey(product.id),
+          productId: product.id,
+          imageUrl: product.imageUrl,
+          title: product.title,
+          price: product.price,
+          isFavorite: isFavorite,
+          onFavoriteToggle: () {
+            context.read<FavoritesCubit>().toggleFavorite(product.id, FavoriteType.product);
+          },
+        );
+      },
     );
   }
 }

--- a/apps/customer/lib/presentation/screens/more_trending/more_trending_screen.dart
+++ b/apps/customer/lib/presentation/screens/more_trending/more_trending_screen.dart
@@ -7,7 +7,6 @@ import '../../../core/navigate/app_routes.dart';
 import '../../../core/navigate/route_args.dart';
 import '../../../domain/repositories/product_repository.dart';
 import '../../cubits/favorites/cubit/favorites_cubit.dart';
-import '../../cubits/favorites/cubit/favorites_state.dart';
 import 'cubit/more_trending_cubit.dart';
 import 'cubit/more_trending_state.dart';
 
@@ -25,10 +24,8 @@ class _MoreTrendingScreenState extends State<MoreTrendingScreen> {
   @override
   void initState() {
     super.initState();
-
     cubit = MoreTrendingCubit(context.read<ProductRepository>());
     cubit.loadTrendingProducts();
-
     _scrollController.addListener(_onScroll);
   }
 
@@ -105,58 +102,46 @@ class _MoreTrendingContent extends StatelessWidget {
           final screenWidth = constraints.crossAxisExtent;
           const cardWidth = 170.0;
           final crossAxisCount = (screenWidth / cardWidth).floor().clamp(2, 6);
-          
-          return BlocBuilder<FavoritesCubit, FavoritesState>(
-            builder: (context, favState) {
-              return SliverGrid(
-                delegate: SliverChildBuilderDelegate(
+
+          return SliverGrid(
+            delegate: SliverChildBuilderDelegate(
                   (context, index) {
-                    final product = state.items[index];
-                    final productId = product.id;
+                final product = state.items[index];
+                final imageUrl = product.images.isNotEmpty
+                    ? product.images.first
+                    : AppImages.cartProduct;
 
-                    // Use FavoritesCubit as source of truth for state sync
-                    final isFavorite = favState.productIds.contains(productId);
-
-                    final imageUrl = product.images.first;
-
-                    return SellioProductVerticalCard(
-                      key: ValueKey(productId),
-                      productId: productId,
-                      imageUrl: imageUrl,
-                      title: product.title,
-                      price: product.price.toString(),
-                      isFavorite: isFavorite,
-                      onFavoriteToggle: () async {
-                        // Pessimistic update: wait for API response
-                        final success = await context
-                            .read<FavoritesCubit>()
-                            .toggleProductFavorite(productId);
-                        return success;
-                      },
-                      onTap: () {
-                        GoRouter.of(context).push(
-                          AppRoutes.productDetails.path,
-                          extra: ProductDetailsArgs(productId: product.id),
-                        );
-                      },
+                return SellioProductVerticalCard(
+                  key: ValueKey(product.id),
+                  productId: product.id,
+                  imageUrl: imageUrl,
+                  title: product.title,
+                  price: product.price.toString(),
+                  isFavorite: product.isFavorite,
+                  onFavoriteToggle: () {
+                    context.read<FavoritesCubit>().toggleFavorite(product.id, FavoriteType.product);
+                  },
+                  onTap: () {
+                    GoRouter.of(context).push(
+                      AppRoutes.productDetails.path,
+                      extra: ProductDetailsArgs(productId: product.id),
                     );
                   },
-                  childCount: state.items.length,
-                ),
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: crossAxisCount,
-                  crossAxisSpacing: 8,
-                  mainAxisSpacing: 12,
-                  childAspectRatio: 160 / 200,
-                ),
-              );
-            },
+                );
+              },
+              childCount: state.items.length,
+            ),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 12,
+              childAspectRatio: 160 / 200,
+            ),
           );
         },
       ),
     );
   }
-
   Widget _buildLoadingMore() {
     return const SliverToBoxAdapter(
       child: Padding(
@@ -166,4 +151,3 @@ class _MoreTrendingContent extends StatelessWidget {
     );
   }
 }
-

--- a/apps/customer/lib/presentation/screens/product_details/cubit/product_details_cubit.dart
+++ b/apps/customer/lib/presentation/screens/product_details/cubit/product_details_cubit.dart
@@ -1,82 +1,76 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:sellio_mobile/core/error/result.dart';
 import 'package:sellio_mobile/domain/repositories/product_repository.dart';
 import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_cubit.dart';
+import '../../../../core/error/result.dart';
+import '../../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../../cubits/favorites/cubit/favorites_state.dart';
 import 'product_details_state.dart';
 
 class ProductDetailsCubit extends Cubit<ProductDetailsState> {
   final ProductRepository _repository;
   final CartCubit _cartCubit;
+  final FavoritesCubit _favoritesCubit;
 
   ProductDetailsCubit(
       this._repository,
       this._cartCubit,
+      this._favoritesCubit,
       ) : super(const ProductDetailsInitial());
 
   final TextEditingController noteController = TextEditingController();
 
-  // ---------------------------------------------------------
-  // LOAD PRODUCT DETAILS
-  // ---------------------------------------------------------
   Future<void> loadProductDetails(String productId) async {
     debugPrint('Loading product details for productId: $productId');
     emit(ProductDetailsLoading(productId: productId));
 
     final productResult = await _repository.getProductById(productId);
-    final favoriteResult = await _repository.isFavorite(productId);
 
-    debugPrint('Product result: $productResult');
-    debugPrint('Favorite result: $favoriteResult');
-
-    if (productResult is Success) {
-      // If favorites check fails, default to false - it shouldn't block product loading
-      final isFavorite = favoriteResult is Success ? favoriteResult.data : false;
-      
-      final cartState = _cartCubit.state;
-      final count = cartState.productCounts[productId] ?? 0;
-
-      debugPrint('Cart count for productId $productId: $count');
-
-      emit(ProductDetailsLoaded(
-        product: productResult.data,
-        isFavorite: isFavorite,
-        productCount: count,
-        note: noteController.text,
-      ));
-
-      debugPrint('ProductDetailsLoaded emitted with product: ${productResult.data}');
-    } else {
+    if (productResult is! Success) {
       final errorMessage = _extractErrorMessage([productResult]);
-      debugPrint('Error loading product details: $errorMessage');
       emit(ProductDetailsError(message: errorMessage));
+      return;
     }
+
+    final product = productResult.data;
+    final cartState = _cartCubit.state;
+    final count = cartState.productCounts[productId] ?? 0;
+
+    final favState = _favoritesCubit.state;
+    final isFavorite = favState is FavoritesLoaded &&
+        favState.favoriteProductIds.contains(productId);
+
+    emit(ProductDetailsLoaded(
+      product: product,
+      isFavorite: isFavorite,
+      productCount: count,
+      note: noteController.text,
+    ));
   }
 
-  // ---------------------------------------------------------
-  // UPDATE NOTE
-  // ---------------------------------------------------------
   void updateNote(String newNote) {
-    debugPrint('Updating note to: $newNote');
     final currentState = state;
     if (currentState is! ProductDetailsLoaded) return;
 
     noteController.text = newNote;
     emit(currentState.copyWith(note: newNote));
-    debugPrint('Note updated, new state: $currentState');
   }
 
-  // ---------------------------------------------------------
-  // ADD TO CART
-  // ---------------------------------------------------------
-  void addToCart() {
+  void toggleFavorite() {
+    final currentState = state;
+    if (currentState is! ProductDetailsLoaded) return;
+
+    _favoritesCubit.toggleFavorite(currentState.product.id, FavoriteType.product);
+
+    final updatedFavorite = !currentState.isFavorite;
+    emit(currentState.copyWith(isFavorite: updatedFavorite));
+  }
+
+   void addToCart() {
     final currentState = state;
     if (currentState is! ProductDetailsLoaded) return;
 
     final product = currentState.product;
-    debugPrint('Adding product to cart: ${product.title}');
-
-    // Get product image, use empty string if no images available
     final productImage = product.images.isNotEmpty ? product.images.first : '';
 
     _cartCubit.addToCart(
@@ -88,27 +82,17 @@ class ProductDetailsCubit extends Cubit<ProductDetailsState> {
       quantity: 1,
     );
 
-    // 🔥 1) Emit SIDE EFFECT
     emit(const ProductDetailsAddToCartSuccess(
       message: 'Product added successfully',
     ));
-    debugPrint('ProductDetailsAddToCartSuccess emitted');
 
-    // 🔥 2) Re-emit UI state to keep screen stable
-    emit(currentState.copyWith(
-      productCount: currentState.productCount + 1,
-    ));
-    debugPrint('Product count incremented, new state: $currentState');
+    emit(currentState.copyWith(productCount: currentState.productCount + 1));
   }
 
-  // ---------------------------------------------------------
-  // ERROR HANDLING
-  // ---------------------------------------------------------
-  String _extractErrorMessage(List<Result> results) {
+  String _extractErrorMessage(List results) {
     for (final result in results) {
-      if (result is ResultFailure) {
-        debugPrint('Error result: ${result.failure.message}');
-        return result.failure.message;
+      if (result is! Success) {
+        return "Something went wrong";
       }
     }
     return 'Something went wrong';
@@ -116,7 +100,6 @@ class ProductDetailsCubit extends Cubit<ProductDetailsState> {
 
   @override
   Future<void> close() {
-    debugPrint('Closing ProductDetailsCubit');
     noteController.dispose();
     return super.close();
   }

--- a/apps/customer/lib/presentation/screens/product_details/product_details_screen.dart
+++ b/apps/customer/lib/presentation/screens/product_details/product_details_screen.dart
@@ -1,6 +1,7 @@
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import 'package:sellio_mobile/domain/repositories/product_repository.dart';
 import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_cubit.dart';
@@ -22,14 +23,19 @@ class ProductDetailsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => ProductDetailsCubit(
-        context.read<ProductRepository>(),
-        context.read<CartCubit>(),
-      )..loadProductDetails(productId),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) => ProductDetailsCubit(
+            context.read<ProductRepository>(),
+            context.read<CartCubit>(),
+            context.read<FavoritesCubit>(),
+          )..loadProductDetails(productId),
+        ),
+      ],
       child: BlocListener<ProductDetailsCubit, ProductDetailsState>(
         listenWhen: (previous, current) =>
-            current is ProductDetailsAddToCartSuccess,
+        current is ProductDetailsAddToCartSuccess,
         listener: (context, state) {
           if (state is ProductDetailsAddToCartSuccess) {
             SellioSnackBar(
@@ -49,26 +55,36 @@ class ProductDetailsScreen extends StatelessWidget {
               preferredSize: const Size.fromHeight(56),
               child: BlocBuilder<ProductDetailsCubit, ProductDetailsState>(
                 builder: (context, state) {
-                  final title = (state is ProductDetailsLoaded)
+                  final title = state is ProductDetailsLoaded
                       ? state.product.title
                       : null;
-                  final isFavorite = (state is ProductDetailsLoaded)
-                      ? state.product.isFavorite
-                      : false;
+
                   return SellioAppBar(
                     showBackButton: true,
                     title: title,
                     actions: [
                       state is ProductDetailsLoading
-                          ? ProductDetailsAppbarShimmer(height: 20, width: 100)
-                          : productFavorite(context, productId, isFavorite)
+                          ? const ProductDetailsAppbarShimmer(
+                          height: 20, width: 100,)
+                          : IconButton(
+                        icon: SvgPicture.asset(
+                          state is ProductDetailsLoaded &&
+                              state.isFavorite
+                              ? AppImages.favorite
+                              : AppImages.unselectedFavorite,
+                        ),
+                        onPressed: () {
+                          context
+                              .read<ProductDetailsCubit>()
+                              .toggleFavorite();
+                        },
+                      ),
                     ],
                   );
                 },
               ),
             ),
 
-            // ---------------- BODY ----------------
             body: BlocBuilder<ProductDetailsCubit, ProductDetailsState>(
               builder: (context, state) {
                 if (state is ProductDetailsLoading) {
@@ -81,15 +97,15 @@ class ProductDetailsScreen extends StatelessWidget {
                       return SingleChildScrollView(
                         padding: const EdgeInsets.only(bottom: 100),
                         child: ConstrainedBox(
-                          constraints:
-                              BoxConstraints(minHeight: constraints.maxHeight),
+                          constraints: BoxConstraints(
+                              minHeight: constraints.maxHeight),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               productImagesSection(),
                               Padding(
                                 padding:
-                                    const EdgeInsets.symmetric(horizontal: 16),
+                                const EdgeInsets.symmetric(horizontal: 16),
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
@@ -111,9 +127,8 @@ class ProductDetailsScreen extends StatelessWidget {
               },
             ),
 
-            // ---------------- BOTTOM BUTTON ----------------
             bottomNavigationBar:
-                BlocBuilder<ProductDetailsCubit, ProductDetailsState>(
+            BlocBuilder<ProductDetailsCubit, ProductDetailsState>(
               builder: (context, state) {
                 if (state is! ProductDetailsLoaded) return const SizedBox();
                 return SafeArea(
@@ -130,6 +145,7 @@ class ProductDetailsScreen extends StatelessWidget {
     );
   }
 }
+
 
 Widget _buildPriceAndCounterRow(
     BuildContext context, ProductDetailsLoaded state) {
@@ -187,29 +203,6 @@ Widget _buildAddToCartButton(BuildContext context) {
         text: context.local.add_to_cart,
         onTap: () => context.read<ProductDetailsCubit>().addToCart(),
         suffixSvgPath: AppImages.cartSmall,
-      );
-    },
-  );
-}
-
-Widget productFavorite(
-    BuildContext context, String productId, bool isFavorite) {
-  return BlocBuilder<FavoritesCubit, FavoritesState>(
-    builder: (context, favoritesState) {
-      //final isFavorite = favoritesState.productIds.contains(productId);
-
-      return FavoriteToggleButton(
-        productId: productId,
-        isFavorite: isFavorite,
-        onToggle: () async {
-          // Pessimistic update: wait for API response before updating UI
-          final success = await context
-              .read<FavoritesCubit>()
-              .toggleProductFavorite(productId);
-          return success;
-        },
-        size: 24,
-        showBackground: false,
       );
     },
   );

--- a/apps/customer/lib/presentation/screens/store_details/store_details_screen.dart
+++ b/apps/customer/lib/presentation/screens/store_details/store_details_screen.dart
@@ -1,51 +1,56 @@
 import 'package:design_system/design_system.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import 'package:sellio_mobile/core/navigate/routing.dart';
 import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_cubit.dart';
 import 'package:sellio_mobile/presentation/cubits/cart/cubit/cart_state.dart';
-import 'package:sellio_mobile/presentation/screens/store_details/widgets/store_details_screen_appBar_shimmer.dart';
-import 'package:sellio_mobile/presentation/screens/store_details/widgets/store_details_screen_shimmer.dart';
 
-import '../../../../../../domain/repositories/store_repository.dart';
 import '../../../domain/entities/category.dart';
 import '../../../domain/entities/product.dart';
 import '../../../domain/entities/store.dart';
 import '../../../domain/entities/store_rating.dart';
+
+import '../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../cubits/favorites/cubit/favorites_state.dart';
+
 import 'cubit/store_details_cubit.dart';
 import 'cubit/store_details_state.dart';
+
 import 'widgets/featured_items_section.dart';
 import 'widgets/store_category_tabs.dart';
 import 'widgets/store_header.dart';
 import 'widgets/store_info_card.dart';
 import 'widgets/store_products_list.dart';
+import 'widgets/store_details_screen_shimmer.dart';
+import 'widgets/store_details_screen_appBar_shimmer.dart';
 
 class StoreDetailsScreen extends StatefulWidget {
   final String storeId;
 
-  const StoreDetailsScreen({
-    super.key,
-    required this.storeId,
-  });
+  const StoreDetailsScreen({super.key, required this.storeId});
 
   @override
   State<StoreDetailsScreen> createState() => _StoreDetailsScreenState();
 }
 
 class _StoreDetailsScreenState extends State<StoreDetailsScreen> {
+  late final StoreDetailsCubit cubit;
   int _selectedCategoryIndex = 0;
-  bool _isFavorite = false;
+
+  @override
+  void initState() {
+    super.initState();
+    cubit = StoreDetailsCubit(context.read());
+    cubit.loadStoreDetails(widget.storeId);
+  }
 
   @override
   Widget build(BuildContext context) {
-    final theme = context.theme;
-    final colors = theme.colors;
+    final colors = context.theme.colors;
 
-    return BlocProvider(
-      create: (context) => StoreDetailsCubit(context.read<StoreRepository>())
-        ..loadStoreDetails(widget.storeId),
+    return BlocProvider.value(
+      value: cubit,
       child: BlocBuilder<StoreDetailsCubit, StoreDetailsState>(
         builder: (context, state) {
           return Scaffold(
@@ -58,33 +63,33 @@ class _StoreDetailsScreenState extends State<StoreDetailsScreen> {
     );
   }
 
+  // ---------------- BODY ----------------
+
   Widget _buildBody(BuildContext context, StoreDetailsState state) {
     if (state is StoreDetailsLoading || state is StoreDetailsInitial) {
       return const StoreDetailsShimmer();
     }
 
     if (state is StoreDetailsError) {
-      return _buildErrorView(context, state);
+      return Center(child: Text(state.message));
     }
 
     if (state is StoreDetailsLoaded) {
       final store = state.store;
       final rating = state.rating;
-      final products = state.products;
-      final featuredProducts = state.featuredProducts;
-      final categories = store.categories;
+      final products = state.products ?? [];
+      final featuredProducts = state.featuredProducts ?? [];
 
       return CustomScrollView(
         slivers: [
           _buildStoreHeader(store),
           if (rating != null) _buildStoreInfoCard(store, rating),
-          if (featuredProducts != null && featuredProducts.isNotEmpty)
-            _buildFeaturedItemsSection(featuredProducts),
-          _buildSectionSpacing(),
-          if (products != null && categories.isNotEmpty)
-            _buildCategoryTabs(store),
-          if (products != null && products.isNotEmpty)
-            _buildProductsList(products, categories),
+          if (featuredProducts.isNotEmpty)
+            SliverToBoxAdapter(
+              child: FeaturedItemsSection(products: featuredProducts),
+            ),
+          _buildCategoryTabs(store),
+          _buildProductsList(products, store.categories),
         ],
       );
     }
@@ -92,200 +97,12 @@ class _StoreDetailsScreenState extends State<StoreDetailsScreen> {
     return const SizedBox.shrink();
   }
 
-  Widget _buildErrorView(BuildContext context, StoreDetailsError state) {
-    final theme = context.theme;
-    final colors = theme.colors;
-    final textTheme = theme.typography.textTheme;
-
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.error_outline,
-              size: 64,
-              color: colors.red,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.local.unable_to_load_store_details,
-              style: textTheme.headlineSmall.copyWith(
-                color: colors.title,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              state.message.isNotEmpty
-                  ? state.message
-                  : context.local.error_generic,
-              style: textTheme.bodyMedium.copyWith(
-                color: colors.body,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            if (state.failedCall != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                '${context.local.failed_to_load}: ${state.failedCall}',
-                style: textTheme.bodySmall.copyWith(
-                  color: colors.hint,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: () {
-                context.read<StoreDetailsCubit>().retry();
-              },
-              icon: const Icon(Icons.refresh),
-              label: Text(context.local.retry),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colors.primary,
-                foregroundColor: colors.onPrimary,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 24,
-                  vertical: 12,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildNoProductsMessage() {
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          children: [
-            Icon(
-              Icons.inventory_2_outlined,
-              size: 48,
-              color: Colors.grey[400],
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.local.no_products_available,
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey[600],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildStoreHeader(Store store) {
-    return SliverToBoxAdapter(
-      child: StoreHeader(
-        coverImage: store.coverImage.isNotEmpty
-            ? store.coverImage
-            : AppImages.storeSweet,
-        profileImage: store.profileImage.isNotEmpty
-            ? store.profileImage
-            : AppImages.placeholder,
-        storeName: store.name.isNotEmpty ? store.name : context.local.store,
-        discount: store.sale ?? '',
-      ),
-    );
-  }
-
-  Widget _buildStoreInfoCard(Store store, StoreRating rating) {
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          LayoutConstants.paddingHorizontal,
-          LayoutConstants.paddingVertical,
-          LayoutConstants.paddingHorizontal,
-          LayoutConstants.paddingVertical,
-        ),
-        child: StoreInfoOverview(
-          location: store.address.city.isNotEmpty
-              ? store.address.city
-              : context.local.unknown,
-          rating: rating.averageRating.clamp(0.0, 5.0),
-          tags: store.categories.map((category) => category.name).toList(),
-          description: store.description.isNotEmpty
-              ? store.description
-              : context.local.no_description_available,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildFeaturedItemsSection(List<Product> products) {
-    return SliverToBoxAdapter(
-      child: FeaturedItemsSection(products: products),
-    );
-  }
-
-  Widget _buildSectionSpacing() => const SliverToBoxAdapter(
-        child: SizedBox(height: LayoutConstants.sectionSpacing),
-      );
-
-  Widget _buildCategoryTabs(Store store) {
-    return SliverToBoxAdapter(
-      child: StoreCategoryTabs(
-        categories: store.categories,
-        selectedIndex: _selectedCategoryIndex,
-        onCategorySelected: _onCategorySelected,
-      ),
-    );
-  }
-
-  Widget _buildProductsList(List<Product> products, List<Category> categories) {
-    if (products.isEmpty) {
-      return _buildNoProductsMessage();
-    }
-
-    return BlocBuilder<CartCubit, CartState>(
-      builder: (BuildContext context, cartState) {
-        return SliverPadding(
-          padding: const EdgeInsets.all(LayoutConstants.paddingHorizontal),
-          sliver: StoreProductsList(
-            onTap: () {
-              if (products.isNotEmpty) {
-                context.navigator.pushProductDetails(
-                  ProductDetailsArgs(
-                    productId: products[0].id,
-                  ),
-                );
-              }
-            },
-            categoryIndex: _selectedCategoryIndex,
-            products: products,
-            categories: categories.map((c) => c.id).toList(),
-            onIncrement: () {
-              if (products.isNotEmpty) {
-                context.read<CartCubit>().incrementProduct(products[0].id);
-              }
-            },
-            onDecrement: () {
-              if (products.isNotEmpty) {
-                context.read<CartCubit>().decrementProduct(products[0].id);
-              }
-            },
-            count: products.isNotEmpty
-                ? (cartState.productCounts[products[0].id] ?? 0)
-                : 0,
-          ),
-        );
-      },
-    );
-  }
+  // ---------------- APP BAR ----------------
 
   PreferredSizeWidget _buildAppBar(
-      BuildContext context, StoreDetailsState state) {
-    final theme = context.theme;
-    final colors = theme.colors;
+      BuildContext context,
+      StoreDetailsState state,
+      ) {
     final isLoading = state is StoreDetailsLoading;
     final storeName = state is StoreDetailsLoaded ? state.store.name : '';
 
@@ -294,52 +111,100 @@ class _StoreDetailsScreenState extends State<StoreDetailsScreen> {
       title: storeName,
       actions: [
         isLoading
-            ? StoreAppbarShimmer(height: 20, width: 100)
-            : _buildFavoriteButton(colors),
-        isLoading
-            ? StoreAppbarShimmer(height: 20, width: 100)
-            : _buildInfoButton(),
+            ? const StoreAppbarShimmer(height: 20, width: 100)
+            : _buildStoreFavoriteButton(state),
       ],
     );
   }
 
-  Widget _buildFavoriteButton(dynamic colors) {
-    return IconButton(
-      icon: SvgPicture.asset(
-        _isFavorite ? AppImages.favorite : AppImages.unselectedFavorite,
-        width: LayoutConstants.iconSizeMedium,
-        height: LayoutConstants.iconSizeMedium,
+  Widget _buildStoreFavoriteButton(StoreDetailsState state) {
+    if (state is! StoreDetailsLoaded) return const SizedBox.shrink();
+    final store = state.store;
+
+    return BlocBuilder<FavoritesCubit, FavoritesState>(
+      buildWhen: (prev, curr) {
+        if (prev is FavoritesLoaded && curr is FavoritesLoaded) {
+          return prev.favoriteStoreIds != curr.favoriteStoreIds;
+        }
+        return curr is FavoritesLoaded;
+      },
+      builder: (context, favState) {
+        final isFavorite = favState is FavoritesLoaded
+            ? favState.favoriteStoreIds.contains(store.id)
+            : store.isFavorite;
+
+        return IconButton(
+          icon: SvgPicture.asset(
+            isFavorite ? AppImages.favorite : AppImages.unselectedFavorite,
+          ),
+          onPressed: () {
+            context.read<FavoritesCubit>().toggleFavorite(store.id, FavoriteType.store);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildStoreHeader(Store store) {
+    return SliverToBoxAdapter(
+      child: StoreHeader(
+        coverImage: store.coverImage,
+        profileImage: store.profileImage,
+        storeName: store.name,
+        discount: store.sale ?? '',
       ),
-      onPressed: _toggleFavorite,
     );
   }
 
-  Widget _buildInfoButton() {
-    return IconButton(
-      icon: SvgPicture.asset(
-        AppImages.alertCircle,
-        width: LayoutConstants.iconSizeMedium,
-        height: LayoutConstants.iconSizeMedium,
+  Widget _buildStoreInfoCard(Store store, StoreRating rating) {
+    return SliverToBoxAdapter(
+      child: StoreInfoOverview(
+        location: store.address.city,
+        rating: rating.averageRating,
+        tags: store.categories.map((e) => e.name).toList(),
+        description: store.description,
       ),
-      onPressed: _navigateToAboutStore,
     );
   }
 
-  void _onCategorySelected(int index) {
-    setState(() {
-      _selectedCategoryIndex = index;
-    });
-  }
-
-  void _toggleFavorite() {
-    setState(() {
-      _isFavorite = !_isFavorite;
-    });
-  }
-
-  void _navigateToAboutStore() {
-    context.navigator.pushAboutStore(
-      AboutStoreArgs(storeId: widget.storeId),
+  Widget _buildCategoryTabs(Store store) {
+    return SliverToBoxAdapter(
+      child: StoreCategoryTabs(
+        categories: store.categories,
+        selectedIndex: _selectedCategoryIndex,
+        onCategorySelected: (index) {
+          setState(() => _selectedCategoryIndex = index);
+        },
+      ),
     );
+  }
+
+  Widget _buildProductsList(
+      List<Product> products,
+      List<Category> categories,
+      ) {
+    return BlocBuilder<CartCubit, CartState>(
+      builder: (context, cartState) {
+        return SliverPadding(
+          padding: const EdgeInsets.all(LayoutConstants.paddingHorizontal),
+          sliver: StoreProductsList(
+            products: products,
+            categories: categories.map((c) => c.id).toList(),
+            categoryIndex: _selectedCategoryIndex,
+            onTap: (product) {
+              context.navigator.pushProductDetails(
+                ProductDetailsArgs(productId: product.id),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    cubit.close();
+    super.dispose();
   }
 }

--- a/apps/customer/lib/presentation/screens/store_details/widgets/featured_items_section.dart
+++ b/apps/customer/lib/presentation/screens/store_details/widgets/featured_items_section.dart
@@ -2,31 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:design_system/design_system.dart';
-import 'package:design_system/design_system.dart';
-import 'package:design_system/design_system.dart';
 import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import 'package:sellio_mobile/core/navigate/navigation_extensions.dart';
-import 'package:sellio_mobile/presentation/cubits/favorites/cubit/favorites_cubit.dart';
-import 'package:sellio_mobile/presentation/cubits/favorites/cubit/favorites_state.dart';
-import 'package:design_system/design_system.dart';
 import '../../../../core/navigate/route_args.dart';
 import '../../../../domain/entities/product.dart';
-import '../../../cubits/cart/cubit/cart_cubit.dart';
-import '../../../cubits/cart/cubit/cart_state.dart';
+import '../../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../../cubits/favorites/cubit/favorites_state.dart';
 
-class FeaturedItemsSection extends StatefulWidget {
+class FeaturedItemsSection extends StatelessWidget {
   final List<Product> products;
 
-  const FeaturedItemsSection({super.key, required this.products});
+  const FeaturedItemsSection({
+    super.key,
+    required this.products,
+  });
 
-  @override
-  State<FeaturedItemsSection> createState() => _FeaturedItemsSectionState();
-}
-
-class _FeaturedItemsSectionState extends State<FeaturedItemsSection> {
   @override
   Widget build(BuildContext context) {
-    if (widget.products.isEmpty) return const SizedBox.shrink();
+    if (products.isEmpty) return const SizedBox.shrink();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -47,50 +40,56 @@ class _FeaturedItemsSectionState extends State<FeaturedItemsSection> {
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: widget.products.length,
+            itemCount: products.length,
             separatorBuilder: (_, __) => const SizedBox(width: 12),
             itemBuilder: (context, index) {
-              final product = widget.products[index];
+              final product = products[index];
 
               return GestureDetector(
                 onTap: () => context.navigator.pushProductDetails(
-                  ProductDetailsArgs(
-                    productId: product.id,
-                  ),
+                  ProductDetailsArgs(productId: product.id),
                 ),
                 child: SizedBox(
                   width: 160,
-                  child: BlocBuilder<CartCubit, CartState>(
-                    builder: (BuildContext context, cartState) {
-                      return BlocBuilder<FavoritesCubit, FavoritesState>(
-                        builder: (BuildContext context, favState) {
-                          final isFavorite = favState.productIds.contains(product.id);
-                          return SellioProductVerticalCard(
-                            productId: product.id,
-                            imageUrl: product.images.isNotEmpty
-                                ? product.images.first
-                                : AppImages.cartProduct,
-                            title: product.title,
-                            price: '\$${product.price}',
-                            isFavorite: isFavorite,
-                            onFavoriteToggle: () async {
-                              // Pessimistic update: wait for API response before updating UI
-                              final success = await context
-                                  .read<FavoritesCubit>()
-                                  .toggleProductFavorite(product.id);
-                              return success;
-                            },
-                          );
-                        },
-                      );
-                    },
-                  ),
+                  child: _FeaturedProductCard(product: product),
                 ),
               );
             },
           ),
         ),
       ],
+    );
+  }
+}
+
+class _FeaturedProductCard extends StatelessWidget {
+  final Product product;
+
+  const _FeaturedProductCard({required this.product});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FavoritesCubit, FavoritesState>(
+      builder: (context, state) {
+        bool isFavorite = product.isFavorite;
+
+        if (state is FavoritesLoaded) {
+          isFavorite = state.favoriteProductIds.contains(product.id);
+        }
+
+        return SellioProductVerticalCard(
+          productId: product.id,
+          imageUrl: product.images.isNotEmpty
+              ? product.images.first
+              : AppImages.cartProduct,
+          title: product.title,
+          price: '\$${product.price}',
+          isFavorite: isFavorite,
+          onFavoriteToggle: () {
+            context.read<FavoritesCubit>().toggleFavorite(product.id, FavoriteType.product);
+          },
+        );
+      },
     );
   }
 }

--- a/apps/customer/lib/presentation/screens/store_details/widgets/store_header.dart
+++ b/apps/customer/lib/presentation/screens/store_details/widgets/store_header.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'package:design_system/design_system.dart';
 import 'store_discount_frame.dart';
 
@@ -36,7 +35,9 @@ class StoreHeader extends StatelessWidget {
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
                   image: DecorationImage(
-                    image: AssetImage(coverImage),
+                    image: coverImage.startsWith('http')
+                        ? NetworkImage(coverImage)
+                        : AssetImage(coverImage) as ImageProvider,
                     fit: BoxFit.cover,
                   ),
                 ),
@@ -55,7 +56,9 @@ class StoreHeader extends StatelessWidget {
                 ),
                 child: CircleAvatar(
                   radius: 48,
-                  backgroundImage: AssetImage(profileImage),
+                  backgroundImage: profileImage.startsWith('http')
+                      ? NetworkImage(profileImage)
+                      : AssetImage(profileImage) as ImageProvider,
                 ),
               ),
             ),
@@ -73,7 +76,6 @@ class StoreHeader extends StatelessWidget {
 
         const SizedBox(height: 44),
 
-        // Store Name
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Align(

--- a/apps/customer/lib/presentation/screens/store_details/widgets/store_products_list.dart
+++ b/apps/customer/lib/presentation/screens/store_details/widgets/store_products_list.dart
@@ -3,39 +3,27 @@ import 'package:design_system/design_system.dart';
 import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import '../../../../../../domain/entities/product.dart';
 
-class StoreProductsList extends StatefulWidget {
+class StoreProductsList extends StatelessWidget {
   final int categoryIndex;
   final List<Product> products;
   final List<String> categories;
-  final VoidCallback? onTap;
-  final VoidCallback onIncrement;
-  final VoidCallback onDecrement;
-  final int count;
+  final void Function(Product) onTap;
 
   const StoreProductsList({
     super.key,
     required this.categoryIndex,
     required this.products,
     required this.categories,
-    this.onTap,
-    required this.onIncrement,
-    required this.onDecrement,
-    required this.count,
+    required this.onTap,
+
   });
 
-  @override
-  State<StoreProductsList> createState() => _StoreProductsListState();
-}
-
-class _StoreProductsListState extends State<StoreProductsList> {
-  static const double _itemSpacing = 12.0;
-
   List<Product> get filteredProducts {
-    if (widget.categories.isEmpty || widget.categoryIndex >= widget.categories.length) {
-      return widget.products;
+    if (categories.isEmpty || categoryIndex >= categories.length) {
+      return products;
     }
-    final selectedCategoryId = widget.categories[widget.categoryIndex];
-    return widget.products.where((p) => p.categoryId == selectedCategoryId).toList();
+    final selectedCategoryId = categories[categoryIndex];
+    return products.where((p) => p.categoryId == selectedCategoryId).toList();
   }
 
   @override
@@ -55,21 +43,17 @@ class _StoreProductsListState extends State<StoreProductsList> {
       delegate: SliverChildBuilderDelegate(
             (context, index) {
           final product = filteredProducts[index];
-          return GestureDetector(
-            onTap: widget.onTap,
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: _itemSpacing),
-              child: SellioProductHorizontalCard(
-                imageUrl: product.images.isNotEmpty 
-                    ? product.images.first 
-                    : AppImages.cartProduct,
-                title: product.title,
-                description: product.description,
-                price: product.price.toString(),
-                count: widget.count,
-                onIncrement: () => widget.onIncrement,
-                onDecrement: () => widget.onDecrement,
-              ),
+
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12.0),
+            child: SellioProductHorizontalCard(
+              imageUrl: product.images.isNotEmpty
+                  ? product.images.first
+                  : AppImages.cartProduct,
+              title: product.title,
+              description: product.description,
+              price: product.price.toString(),
+              onTap: () => onTap(product),
             ),
           );
         },

--- a/apps/customer/lib/presentation/screens/thrift/thrift_screen.dart
+++ b/apps/customer/lib/presentation/screens/thrift/thrift_screen.dart
@@ -5,13 +5,12 @@ import 'package:go_router/go_router.dart';
 import 'package:sellio_mobile/core/localization/l10n/localization_service.dart';
 import 'package:sellio_mobile/presentation/screens/thrift/widgets/thrift_screen_loadingMore_shimmer.dart';
 import 'package:sellio_mobile/presentation/screens/thrift/widgets/thrift_screen_shimmer.dart';
-
 import '../../../../domain/repositories/category_repository.dart';
 import '../../../../domain/repositories/product_repository.dart';
 import '../../../core/navigate/app_routes.dart';
 import '../../../core/navigate/route_args.dart';
-import '../../cubits/cart/cubit/cart_cubit.dart';
 import '../../cubits/favorites/cubit/favorites_cubit.dart';
+import '../../cubits/favorites/cubit/favorites_state.dart';
 import 'cubit/thrift_products_cubit.dart';
 import 'cubit/thrift_products_state.dart';
 import 'widgets/category_tabs.dart';
@@ -24,7 +23,7 @@ class ThriftScreen extends StatefulWidget {
 }
 
 class _ThriftScreenState extends State<ThriftScreen> {
-  late ThriftProductsCubit cubit;
+  late final ThriftProductsCubit cubit;
   final ScrollController _scrollController = ScrollController();
 
   @override
@@ -62,6 +61,13 @@ class _ThriftScreenState extends State<ThriftScreen> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    cubit.close();
+    super.dispose();
+  }
 }
 
 class ThriftContent extends StatelessWidget {
@@ -73,8 +79,8 @@ class ThriftContent extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ThriftProductsCubit, ThriftProductsState>(
       builder: (context, state) {
-        if (state.isLoading) {
-          return ThriftScreenLoadingMoreShimmer();
+        if (state.isLoading && state.items.isEmpty) {
+          return const ThriftScreenLoadingMoreShimmer();
         }
 
         return RefreshIndicator(
@@ -84,7 +90,7 @@ class ThriftContent extends StatelessWidget {
             slivers: [
               _buildCategoryTabs(context, state),
               _buildProductsGrid(context, state),
-              if (state.isLoadingMore) ThriftLoadingMoreShimmer(),
+              if (state.isLoadingMore) const ThriftLoadingMoreShimmer(),
             ],
           ),
         );
@@ -101,15 +107,17 @@ class ThriftContent extends StatelessWidget {
         name: context.local.all,
         icon: AppImages.allCategories,
       ),
-      ...state.categories.map((c) => CategoryTabData(
-            id: c.id,
-            name: c.name,
-            icon: _mapCategoryIcon(c.name),
-          )),
+      ...state.categories.map(
+            (c) => CategoryTabData(
+          id: c.id,
+          name: c.name,
+          icon: _mapCategoryIcon(c.name),
+        ),
+      ),
     ];
 
     final selectedIndex =
-        tabs.indexWhere((t) => t.id == state.selectedCategoryId);
+    tabs.indexWhere((t) => t.id == state.selectedCategoryId);
 
     return SliverToBoxAdapter(
       child: CategoryTabs(
@@ -140,14 +148,14 @@ class ThriftContent extends StatelessWidget {
     if (state.items.isEmpty) {
       return SliverFillRemaining(
         child: Center(
-            child: EmptySection(
-                icon: AppImages.noOrderHistory,
-                title: context.local.no_products_found,
-                description: context.local.you_can_dicover_more_products,
-                buttonText: context.local.start_exploring_more,
-                color: context.theme.colors.purpleVariant,
-                onTap: () {},
-            ),
+          child: EmptySection(
+            icon: AppImages.noOrderHistory,
+            title: context.local.no_products_found,
+            description: context.local.you_can_dicover_more_products,
+            buttonText: context.local.start_exploring_more,
+            color: context.theme.colors.purpleVariant,
+            onTap: () {},
+          ),
         ),
       );
     }
@@ -159,40 +167,40 @@ class ThriftContent extends StatelessWidget {
           final screenWidth = constraints.crossAxisExtent;
           const cardWidth = 170.0;
           final crossAxisCount = (screenWidth / cardWidth).floor().clamp(1, 6);
+
           return SliverGrid(
             delegate: SliverChildBuilderDelegate(
-              (context, index) {
+                  (context, index) {
                 final product = state.items[index];
-                final productId = product.id;
 
-                final cart = context.watch<CartCubit>();
-                final favorites = context.watch<FavoritesCubit>();
+                return BlocBuilder<FavoritesCubit, FavoritesState>(
+                  builder: (context, favState) {
+                    bool isFavorite = product.isFavorite;
+                    if (favState is FavoritesLoaded) {
+                      isFavorite =
+                          favState.favoriteProductIds.contains(product.id);
+                    }
 
-                final count = cart.state.productCounts[productId] ?? 0;
-                final isFavorite =
-                    favorites.state.productIds.contains(productId);
-
-                final imageUrl =
-                    product.images.isNotEmpty ? product.images.first : '';
-
-                return SellioProductVerticalCard(
-                  key: ValueKey(productId),
-                  productId: productId,
-                  imageUrl: imageUrl,
-                  title: product.title,
-                  price: product.price.toString(),
-                  isFavorite: isFavorite,
-                  onFavoriteToggle: () async {
-                    // Pessimistic update: wait for API response before updating UI
-                    final success = await context
-                        .read<FavoritesCubit>()
-                        .toggleProductFavorite(productId);
-                    return success;
-                  },
-                  onTap: () {
-                    GoRouter.of(context).push(
-                      AppRoutes.productDetails.path,
-                      extra: ProductDetailsArgs(productId: product.id),
+                    return SellioProductVerticalCard(
+                      key: ValueKey(product.id),
+                      productId: product.id,
+                      imageUrl: product.images.isNotEmpty
+                          ? product.images.first
+                          : '',
+                      title: product.title,
+                      price: product.price.toString(),
+                      isFavorite: isFavorite,
+                      onFavoriteToggle: () {
+                        context
+                            .read<FavoritesCubit>()
+                            .toggleFavorite(product.id, FavoriteType.product);
+                      },
+                      onTap: () {
+                        GoRouter.of(context).push(
+                          AppRoutes.productDetails.path,
+                          extra: ProductDetailsArgs(productId: product.id),
+                        );
+                      },
                     );
                   },
                 );

--- a/packages/design_system/lib/widgets/buttons/favorite_toggle_button.dart
+++ b/packages/design_system/lib/widgets/buttons/favorite_toggle_button.dart
@@ -17,8 +17,7 @@ class FavoriteToggleButton extends StatefulWidget {
   final bool isFavorite;
 
   /// Callback that performs the API call to toggle favorite status
-  /// Should return true on success, false on failure
-  final Future<bool> Function() onToggle;
+  final VoidCallback? onToggle;
 
   /// The size of the button (default: 32)
   final double size;
@@ -36,7 +35,7 @@ class FavoriteToggleButton extends StatefulWidget {
     super.key,
     required this.productId,
     required this.isFavorite,
-    required this.onToggle,
+    this.onToggle,
     this.size = 32,
     this.showBackground = true,
     this.iconColor,
@@ -68,29 +67,21 @@ class _FavoriteToggleButtonState extends State<FavoriteToggleButton> {
   Future<void> _handleToggle() async {
     if (_isLoading) return;
 
-    setState(() {
-      _isLoading = true;
-    });
+    setState(() => _isLoading = true);
 
     try {
-      final success = await widget.onToggle();
+      if (widget.onToggle != null) {
+        await Future.microtask(widget.onToggle!); // just call it, no return needed
+      }
 
-      if (success && mounted) {
+      if (mounted) {
         setState(() {
           _isFavorite = !_isFavorite;
           _isLoading = false;
         });
-      } else if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
       }
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
+      if (mounted) setState(() => _isLoading = false);
     }
   }
 
@@ -145,24 +136,23 @@ class _FavoriteToggleButtonState extends State<FavoriteToggleButton> {
     return Center(
       child: _isLoading
           ? SizedBox(
-              width: widget.size * 0.5,
-              height: widget.size * 0.5,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation<Color>(iconColor),
-              ),
-            )
+        width: widget.size * 0.5,
+        height: widget.size * 0.5,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(iconColor),
+        ),
+      )
           : SvgPicture.asset(
-              _isFavorite ? AppImages.favorite : AppImages.unselectedFavorite,
-              colorFilter: ColorFilter.mode(
-                iconColor,
-                BlendMode.srcIn,
-              ),
-              width: widget.size * 0.625,
-              height: widget.size * 0.625,
-              fit: BoxFit.scaleDown,
-            ),
+        _isFavorite ? AppImages.favorite : AppImages.unselectedFavorite,
+        colorFilter: ColorFilter.mode(
+          iconColor,
+          BlendMode.srcIn,
+        ),
+        width: widget.size * 0.625,
+        height: widget.size * 0.625,
+        fit: BoxFit.scaleDown,
+      ),
     );
   }
 }
-

--- a/packages/design_system/lib/widgets/cards/sellio_product_horizontal_card.dart
+++ b/packages/design_system/lib/widgets/cards/sellio_product_horizontal_card.dart
@@ -10,9 +10,9 @@ class SellioProductHorizontalCard extends StatelessWidget {
   final String description;
   final String price;
   final String? originalPrice;
-  final int count;
-  final VoidCallback onIncrement;
-  final VoidCallback onDecrement;
+  final int? count; // nullable count
+  final VoidCallback? onIncrement; // nullable increment
+  final VoidCallback? onDecrement; // nullable decrement
   final VoidCallback? onTap;
 
   const SellioProductHorizontalCard({
@@ -22,9 +22,9 @@ class SellioProductHorizontalCard extends StatelessWidget {
     required this.description,
     required this.price,
     this.originalPrice,
-    this.count = 0,
-    required this.onIncrement,
-    required this.onDecrement,
+    this.count,
+    this.onIncrement,
+    this.onDecrement,
     this.onTap,
   });
 
@@ -48,6 +48,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // Title
                     Text(
                       title,
                       style: textTheme.titleSmall.copyWith(color: colors.title),
@@ -55,6 +56,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                     const SizedBox(height: 4),
+                    // Description
                     Text(
                       description,
                       style: textTheme.labelXSmall.copyWith(color: colors.body),
@@ -66,9 +68,12 @@ class SellioProductHorizontalCard extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
-                        count == 0
-                            ? _buildSingleCartButton(context)
-                            : _buildCounter(context),
+                        // Show counter if count and callbacks are provided, otherwise single button placeholder
+                        if (count != null && onIncrement != null && onDecrement != null)
+                          _buildCounter(context)
+                        else if (onIncrement != null)
+                          _buildSingleCartButton(context),
+                        // Price
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.baseline,
                           textBaseline: TextBaseline.alphabetic,
@@ -86,8 +91,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                               ),
                             Text(
                               "\$${formatPrice(price)}",
-                              style: textTheme.titleSmall
-                                  .copyWith(color: colors.primary),
+                              style: textTheme.titleSmall.copyWith(color: colors.primary),
                             ),
                           ],
                         ),
@@ -96,6 +100,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                   ],
                 ),
               ),
+              // Image
               Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 12),
                 child: _buildImage(colors),
@@ -123,10 +128,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
           onTap: onIncrement,
           child: SvgPicture.asset(
             AppImages.cart,
-            colorFilter: ColorFilter.mode(
-              colors.primary,
-              BlendMode.srcIn,
-            ),
+            colorFilter: ColorFilter.mode(colors.primary, BlendMode.srcIn),
             width: 20,
             height: 20,
             fit: BoxFit.scaleDown,
@@ -152,6 +154,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
+          // Decrement button
           Container(
             width: 30,
             height: 30,
@@ -166,10 +169,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                 onTap: onDecrement,
                 child: SvgPicture.asset(
                   AppImages.remove,
-                  colorFilter: ColorFilter.mode(
-                    colors.body,
-                    BlendMode.srcIn,
-                  ),
+                  colorFilter: ColorFilter.mode(colors.body, BlendMode.srcIn),
                   width: 16,
                   height: 16,
                   fit: BoxFit.scaleDown,
@@ -177,12 +177,12 @@ class SellioProductHorizontalCard extends StatelessWidget {
               ),
             ),
           ),
+          // Count
           Text(
-            count.toString().padLeft(2, '0'),
-            style: textTheme.labelSmall.copyWith(
-              color: colors.title,
-            ),
+            count?.toString().padLeft(2, '0') ?? '00',
+            style: textTheme.labelSmall.copyWith(color: colors.title),
           ),
+          // Increment button
           Container(
             width: 30,
             height: 30,
@@ -197,10 +197,7 @@ class SellioProductHorizontalCard extends StatelessWidget {
                 onTap: onIncrement,
                 child: SvgPicture.asset(
                   AppImages.add,
-                  colorFilter: ColorFilter.mode(
-                    colors.primary,
-                    BlendMode.srcIn,
-                  ),
+                  colorFilter: ColorFilter.mode(colors.primary, BlendMode.srcIn),
                   width: 16,
                   height: 16,
                   fit: BoxFit.scaleDown,
@@ -225,13 +222,11 @@ class SellioProductHorizontalCard extends StatelessWidget {
           return progress == null
               ? child
               : Container(
-                  width: 88,
-                  height: 88,
-                  color: colors.surface,
-                  child: const Center(
-                    child: CircularProgressIndicator(),
-                  ),
-                );
+            width: 88,
+            height: 88,
+            color: colors.surface,
+            child: const Center(child: CircularProgressIndicator()),
+          );
         },
         errorBuilder: (context, error, stackTrace) {
           return Container(

--- a/packages/design_system/lib/widgets/cards/sellio_product_vertical_card.dart
+++ b/packages/design_system/lib/widgets/cards/sellio_product_vertical_card.dart
@@ -1,7 +1,9 @@
-import 'package:design_system/constants/app_images.dart';
+import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:design_system/constants/app_images.dart';
+import '../../themes/sellio_colors.dart';
 import '../../themes/sellio_theme.dart';
-import '../buttons/favorite_toggle_button.dart';
 import '../utils/widgets_utils.dart';
 
 class SellioProductVerticalCard extends StatelessWidget {
@@ -9,9 +11,9 @@ class SellioProductVerticalCard extends StatelessWidget {
   final String title;
   final String price;
   final String productId;
-  final Future<bool> Function()? onFavoriteToggle;
   final bool isFavorite;
   final VoidCallback? onTap;
+  final VoidCallback? onFavoriteToggle;
 
   const SellioProductVerticalCard({
     super.key,
@@ -19,9 +21,9 @@ class SellioProductVerticalCard extends StatelessWidget {
     required this.title,
     required this.price,
     required this.productId,
-    this.onFavoriteToggle,
     this.isFavorite = false,
     this.onTap,
+    this.onFavoriteToggle,
   });
 
   @override
@@ -36,61 +38,43 @@ class SellioProductVerticalCard extends StatelessWidget {
       child: InkWell(
         borderRadius: BorderRadius.circular(8),
         onTap: onTap,
-        child: SizedBox(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Stack(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
-                    child: _buildImage(colors),
-                  ),
-                  if (onFavoriteToggle != null)
-                    Positioned(
-                      top: 8,
-                      right: 8,
-                      child: FavoriteToggleButton(
-                        productId: productId,
-                        isFavorite: isFavorite,
-                        onToggle: onFavoriteToggle!,
-                        size: 32,
-                        showBackground: true,
-                      ),
-                    ),
-                ],
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4 ,vertical: 4),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: Text(
-                    title,
-                    style: textTheme.labelMedium.copyWith(color: colors.title),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Stack(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
+                  child: _buildImage(colors),
                 ),
+                if (onFavoriteToggle != null)
+                  _buildFavoriteButton(colors),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+              child: Text(
+                title,
+                style: textTheme.labelMedium.copyWith(color: colors.title),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: Text(
-                    "\$${formatPrice(price)}",
-                    style: textTheme.titleSmall.copyWith(color: colors.primary),
-                    maxLines: 1,
-                  ),
-                ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                "\$${formatPrice(price)}",
+                style: textTheme.titleSmall.copyWith(color: colors.primary),
+                maxLines: 1,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 
-  Widget _buildImage(colors) {
+  Widget _buildImage(SellioColorScheme colors) {
     return AspectRatio(
       aspectRatio: 1.05,
       child: ClipRRect(
@@ -114,6 +98,45 @@ class SellioProductVerticalCard extends StatelessWidget {
               fit: BoxFit.cover,
             );
           },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFavoriteButton(SellioColorScheme colors) {
+    return Positioned(
+      top: 4,
+      right: 4,
+      child: ClipOval(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 12.0, sigmaY: 12.0),
+          child: Container(
+            width: 32,
+            height: 32,
+            decoration: const BoxDecoration(
+              color: Color(0x99FFFFFF),
+              shape: BoxShape.circle,
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                customBorder: const CircleBorder(),
+                onTap: onFavoriteToggle,
+                child: Center(
+                  child: SvgPicture.asset(
+                    isFavorite ? AppImages.favorite : AppImages.unselectedFavorite,
+                    colorFilter: ColorFilter.mode(
+                      colors.primary,
+                      BlendMode.srcIn,
+                    ),
+                    width: 20,
+                    height: 20,
+                    fit: BoxFit.scaleDown,
+                  ),
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
- Refactored the Favorites feature to unify handling of products and stores.

- Updated FavoritesCubit to maintain full lists of favorite Product and Store objects instead of only IDs.

- Introduced a single toggleFavorite method that handles both product and store favorites based on type.

- Updated UI sections (ProductsGridSection and StoresSection) to use the object lists from the cubit.

- Fixed issues with toggling favorites and ensured optimistic UI updates.

- Removed unnecessary calls to fetch full products or stores in the UI; now the cubit manages all favorite data.