### PR TITLE
436-navigation-back-from-set-new-password-screen

### DIFF
--- a/apps/customer/lib/presentation/screens/auth/forgot_password/confirm_password_screen.dart
+++ b/apps/customer/lib/presentation/screens/auth/forgot_password/confirm_password_screen.dart
@@ -92,7 +92,12 @@ class _SetNewPasswordScreenContentState
         return Scaffold(
           appBar: SellioAppBar(
             title: context.local.title_par_forget_password,
-            showBackButton: true,
+            leading: IconButton(
+              icon: SvgPicture.asset(AppImages.arrowLeft),
+              onPressed: () {
+                context.goNamed(AppRoutes.forgetPassword.name);
+              },
+            ),
           ),
           backgroundColor: colors.surfaceLow,
           body: SafeArea(

--- a/packages/design_system/lib/widgets/sellio_app_bar.dart
+++ b/packages/design_system/lib/widgets/sellio_app_bar.dart
@@ -36,7 +36,7 @@ class SellioAppBar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: Colors.transparent,
       scrolledUnderElevation: 0,
       centerTitle: centerTitle,
-      leadingWidth: showBackButton ? 56 : 110,
+      leadingWidth: leading !=null ? 56: showBackButton ? 56 : 110,
       leading: _buildLeading(context),
       title: customTitle ?? _buildTitle(context, colors, textTheme),
       titleSpacing: 12,


### PR DESCRIPTION
## What Changed
The navigation occurs when the user clicks the back icon, returning them to the Forget Password screen.## 

Screenshots/Videos 

https://github.com/user-attachments/assets/4d4896d7-066a-4b86-87b6-7968d21de4d0

