### PR TITLE
refactor(cart): Enhance order confirmation sheet

### DIFF
--- a/apps/customer/lib/core/localization/l10n/app_en.arb
+++ b/apps/customer/lib/core/localization/l10n/app_en.arb
@@ -61,7 +61,7 @@
   "total_price": "Total price",
   "select": "Select",
   "back_to_shopping": "Back to shopping",
-  "order_received": "Your order has been received successfully.",
+  "order_received": "Your order has been received\n successfully.",
   "current_password": "Current password",
   "new_password": "New password",
   "confirm_new_password": "Confirm new password",

--- a/apps/customer/lib/presentation/screens/cart/widgets/order_confirmation_dialog.dart
+++ b/apps/customer/lib/presentation/screens/cart/widgets/order_confirmation_dialog.dart
@@ -8,8 +8,8 @@ import '../constants/cart_constants.dart';
 
 class OrderConfirmationDialog {
   static Future<void> show(
-    BuildContext context,
-  ) {
+      BuildContext context,
+      ) {
     return showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -19,7 +19,7 @@ class OrderConfirmationDialog {
           top: Radius.circular(CartConstants.bottomSheetRadius),
         ),
       ),
-      builder: (_) => _OrderConfirmationContent(),
+      builder: (_) => const _OrderConfirmationContent(),
     );
   }
 }
@@ -34,16 +34,57 @@ class _OrderConfirmationContent extends StatelessWidget {
     final colors = theme.colors;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+
+          Container(
+            width: 40,
+            height: 4,
+            margin: const EdgeInsets.only(bottom: 24),
+            decoration: BoxDecoration(
+              color: colors.stroke,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
           _buildIcon(colors),
+
+          const Gap(24),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                AppImages.product,
+                width: 18,
+                height: 18,
+                colorFilter: ColorFilter.mode(
+                  colors.title,
+                  BlendMode.srcIn,
+                ),
+              ),
+              const Gap(8),
+              Text(
+                "Order #2002124",
+                style: textTheme.labelMedium.copyWith(
+                  color: colors.title,
+                ),
+              ),
+            ],
+          ),
           const Gap(8),
           Text(
             context.local.order_received,
-            style: textTheme.titleSmall.copyWith(color: colors.title),
+            textAlign: TextAlign.center,
+            style: textTheme.titleSmall.copyWith(
+              color: colors.title,
+            ),
+            maxLines: 2,
           ),
+
+
           const Gap(24),
           _buildBackButton(context, theme),
         ],
@@ -73,10 +114,8 @@ class _OrderConfirmationContent extends StatelessWidget {
   Widget _buildBackButton(BuildContext context, dynamic theme) {
     return SellioButton(
       text: context.local.back_to_shopping,
-      textStyle: context.theme.typography.textTheme.labelMedium.copyWith(
-        color: context.theme.colors.primary,
-      ),
-       //backgroundColor: context.theme.colors.primaryVariant,
+      textColor: context.theme.colors.primary,
+      backgroundColor: context.theme.colors.primaryVariant,
       onTap: () => context.navigator.goToHome(),
       fullWidth: true,
     );


### PR DESCRIPTION
This commit refactors the `OrderConfirmationDialog` to improve its visual presentation and provide more context to the user.

- **UI Enhancements:**
    - A drag handle has been added to the top of the bottom sheet for better affordance.
    - The overall padding has been adjusted.
    - The dialog now displays a static order number ("Order #2002124") with an icon, providing more specific feedback.
    - The success message now supports multiple lines to prevent text overflow.

- **Styling:**
    - The "Back to shopping" button's background and text colors are now explicitly set using theme variables, replacing the previous text style override.

- **Localization:**
    - A newline character (`\n`) has been added to the `order_received` string in the English localization file (`app_en.arb`) to ensure proper line breaking in the updated dialog layout.


## Screenshots
- From figma 
<img width="242" height="464" alt="image" src="https://github.com/user-attachments/assets/b3f63d16-1f83-4398-aa93-afd61df53d60" />

- From app 

<img width="284" height="596" alt="image" src="https://github.com/user-attachments/assets/1e90f179-d6d9-4efd-a9f9-62b169d15fd8" />


