### PR TITLE
ci: Improve GitHub Release with Appetize.io keys

### DIFF
--- a/.github/workflows/build_release_apk.yml
+++ b/.github/workflows/build_release_apk.yml
@@ -173,9 +173,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Embed the JSON directly as the release body so the dashboard
+          # can read it from a single api.github.com call (no binary asset fetch,
+          # no CORS redirect issues).
+          KEYS_CONTENT=$(cat preview-keys.json)
           gh release create preview-keys \
             --title "App Preview Keys (Latest)" \
-            --notes "Auto-generated Appetize.io embed keys. Updated on every merge to develop/main." \
+            --notes "$KEYS_CONTENT" \
             --prerelease \
             preview-keys.json
 


### PR DESCRIPTION
Embed Appetize.io public keys directly into the GitHub Release notes for easier consumption by the dashboard. This avoids separate asset fetches and CORS issues.

## Description
Brief description of changes made in this PR

## What Changed
-

## Screenshots/Videos (if applicable)
<!-- Add screenshots or videos to help explain your changes -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

## Additional Notes

