### PR TITLE
refactor: remove email field from user models and screens

### DIFF
--- a/apps/customer/lib/data/mappers/user_mapper.dart
+++ b/apps/customer/lib/data/mappers/user_mapper.dart
@@ -7,7 +7,6 @@ extension UserModelMapper on UserModel {
   User toEntity() {
     return User(
       fullName: fullName,
-      email: email,
       phoneNumber: phoneNumber,
       avatarUrl: avatarUrl,
       address: Address(

--- a/apps/customer/lib/data/mock/mock_data_generator.dart
+++ b/apps/customer/lib/data/mock/mock_data_generator.dart
@@ -25,8 +25,6 @@ class MockDataGenerator {
 
     return User(
       fullName: fullName,
-      email:
-          '${fullName.toLowerCase()}.$index@example.com',
       phoneNumber: '555${_random.nextInt(1000000).toString().padLeft(7, '0')}',
       avatarUrl: 'https://i.pravatar.cc/150?img=$index',
       address: address,

--- a/apps/customer/lib/data/models/request/update_user_profile_request.dart
+++ b/apps/customer/lib/data/models/request/update_user_profile_request.dart
@@ -9,7 +9,6 @@ part 'update_user_profile_request.g.dart';
 class UpdateUserProfileRequest with _$UpdateUserProfileRequest {
   const factory UpdateUserProfileRequest({
     String? fullName,
-    String? email,
     String? phoneNumber,
     String? city,
     String? country,

--- a/apps/customer/lib/data/models/user_model.dart
+++ b/apps/customer/lib/data/models/user_model.dart
@@ -6,7 +6,6 @@ part 'user_model.g.dart';
 class UserModel with _$UserModel {
   const factory UserModel({
     required String fullName,
-    String? email,
     required String phoneNumber,
     required String city,
     required String country,

--- a/apps/customer/lib/data/repositories/user_repository_impl.dart
+++ b/apps/customer/lib/data/repositories/user_repository_impl.dart
@@ -31,7 +31,6 @@ class UserRepositoryImpl implements UserRepository {
   @override
   Future<Result<User>> updateUserProfile({
     String? fullName,
-    String? email,
     String? phoneNumber,
     String? city,
     String? country,
@@ -40,7 +39,6 @@ class UserRepositoryImpl implements UserRepository {
     return RepositoryCallHandler.call<User>(() async {
       final request = UpdateUserProfileRequest(
         fullName: fullName,
-        email: email,
         phoneNumber: phoneNumber,
         city: city,
         country: country,

--- a/apps/customer/lib/domain/entities/user.dart
+++ b/apps/customer/lib/domain/entities/user.dart
@@ -2,14 +2,12 @@ import 'address.dart';
 
 class User {
   final String fullName;
-  final String? email;
   final String phoneNumber;
   final String? avatarUrl;
   final Address address;
 
   const User({
     required this.fullName,
-    this.email,
     required this.phoneNumber,
     this.avatarUrl,
     required this.address,
@@ -17,7 +15,6 @@ class User {
 
   User copyWith({
     String? fullName,
-    String? email,
     String? phoneNumber,
     String? city,
     String? country,
@@ -26,7 +23,6 @@ class User {
   }) {
     return User(
       fullName: fullName ?? this.fullName,
-      email: email ?? this.email,
       phoneNumber: phoneNumber ?? this.phoneNumber,
       avatarUrl: avatarUrl ?? this.avatarUrl,
       address: address ?? this.address,

--- a/apps/customer/lib/domain/repositories/user_repository.dart
+++ b/apps/customer/lib/domain/repositories/user_repository.dart
@@ -7,7 +7,6 @@ abstract class UserRepository {
 
   Future<Result<User>> updateUserProfile({
     String? fullName,
-    String? email,
     String? phoneNumber,
     String? country,
     String? city,

--- a/apps/customer/lib/presentation/screens/account/account_screen.dart
+++ b/apps/customer/lib/presentation/screens/account/account_screen.dart
@@ -174,11 +174,6 @@ class _AccountScreenState extends State<AccountScreen> {
             state.fullName,
             style: themeText.titleSmall.copyWith(color: colors.title),
           ),
-          if (state.email != null)
-            Text(
-              state.email!,
-              style: themeText.labelSmall.copyWith(color: colors.body),
-            ),
         ],
       ),
     );

--- a/apps/customer/lib/presentation/screens/account/cubit/account_cubit.dart
+++ b/apps/customer/lib/presentation/screens/account/cubit/account_cubit.dart
@@ -25,7 +25,6 @@ class AccountCubit extends Cubit<AccountState> {
     if (authState is LoggedIn) {
       emit(AccountLoaded(
         fullName: authState.user.fullName,
-        email: authState.user.email,
         imagePath: authState.user.avatarUrl,
         notificationsEnabled: true,
       ));

--- a/apps/customer/lib/presentation/screens/account/cubit/account_state.dart
+++ b/apps/customer/lib/presentation/screens/account/cubit/account_state.dart
@@ -16,26 +16,22 @@ class AccountLoading extends AccountState {
 
 class AccountLoaded extends AccountState {
   final String fullName;
-  final String? email;
   final String? imagePath;
   final bool notificationsEnabled;
 
   const AccountLoaded({
     required this.fullName,
-    this.email,
     this.imagePath,
     this.notificationsEnabled = true,
   });
 
   AccountLoaded copyWith({
     String? fullName,
-    String? email,
     String? imagePath,
     bool? notificationsEnabled,
   }) {
     return AccountLoaded(
       fullName: fullName ?? this.fullName,
-      email: email ?? this.email,
       imagePath: imagePath ?? this.imagePath,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
     );
@@ -43,7 +39,7 @@ class AccountLoaded extends AccountState {
 
   @override
   List<Object?> get props =>
-      [fullName, email, imagePath, notificationsEnabled];
+      [fullName, imagePath, notificationsEnabled];
 }
 
 class AccountError extends AccountState {


### PR DESCRIPTION
This commit removes the `email` field from the user-related data structures, domain entities, and UI components across the customer application. This aligns the codebase with a simplified user profile that relies on phone numbers and other identifiers instead of email.

Key changes include:
- Removed `email` property from `UserModel`, `User` entity, and `UpdateUserProfileRequest`.
- Updated `UserMapper` and `MockDataGenerator` to exclude email data.
- Refactored `UserRepository` and its implementation to remove email from profile update methods.
- Updated `AccountCubit` and `AccountState` to remove email state management.
- Removed the email display label from the `AccountScreen` UI.