### PR TITLE
fix: correct selectedCategoryId assignment in ThriftProductsState

### DIFF
--- a/apps/customer/lib/presentation/screens/thrift/cubit/thrift_products_state.dart
+++ b/apps/customer/lib/presentation/screens/thrift/cubit/thrift_products_state.dart
@@ -45,7 +45,7 @@ class ThriftProductsState extends Equatable {
       currentPage: currentPage ?? this.currentPage,
       totalPages: totalPages ?? this.totalPages,
       categories: categories ?? this.categories,
-      selectedCategoryId: selectedCategoryId,
+      selectedCategoryId: selectedCategoryId ?? this.selectedCategoryId,
       errorMessage: errorMessage,
     );
   }


### PR DESCRIPTION

## Description
- fix chip selection 

## Screenshots/Videos (if applicable)




https://github.com/user-attachments/assets/d2700392-8d6a-441a-8b6d-c6c3c5d638c2


