### PR TITLE
fix: hide account options for unauthenticated users in AccountScreen

### DIFF
--- a/apps/customer/lib/presentation/screens/account/account_screen.dart
+++ b/apps/customer/lib/presentation/screens/account/account_screen.dart
@@ -38,7 +38,6 @@ class _AccountScreenState extends State<AccountScreen> {
       ),
       child: BlocBuilder<AccountCubit, AccountState>(
         builder: (context, state) {
-          print("Trace : State in AccountScreen build method: $state");
 
           return Scaffold(
             extendBodyBehindAppBar: false,
@@ -61,6 +60,7 @@ class _AccountScreenState extends State<AccountScreen> {
     return SellioAppBar(
       title: context.local.account_screen,
       actions: [
+        if(state is! UserNotLoggedIn)
         GestureDetector(
           onTap: () => _showAccountOptionsBottomSheet(context),
           child: Padding(


### PR DESCRIPTION
## Description
### fix: hide account options for unauthenticated users in AccountScreen


## Screenshots/Videos (if applicable)

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/3213ff71-8994-4f34-b76d-e9a7096fbb88" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/602da8cc-cdad-493d-b5a6-566215a2e303" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
</table>

