### PR TITLE
fix: shimmer effect bottom overflow for product list

### DIFF
--- a/apps/customer/lib/presentation/screens/home/sections/trending_products/product_list_shimmer.dart
+++ b/apps/customer/lib/presentation/screens/home/sections/trending_products/product_list_shimmer.dart
@@ -48,7 +48,7 @@ class ProductsListShimmerVertical extends StatelessWidget {
         crossAxisCount: 2,
         crossAxisSpacing: 8,
         mainAxisSpacing: 12,
-        childAspectRatio: 170 / 272,
+        childAspectRatio: 160 / 272,
       ),
       itemBuilder: (context, index) {
         return SellioProductVerticalCardShimmer();

--- a/apps/customer/lib/presentation/screens/thrift/widgets/thrift_screen_loadingMore_shimmer.dart
+++ b/apps/customer/lib/presentation/screens/thrift/widgets/thrift_screen_loadingMore_shimmer.dart
@@ -9,6 +9,7 @@ class ThriftLoadingMoreShimmer extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = SellioTheme.of(context);
     final colors = theme.colors;
+
     return SliverPadding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       sliver: SliverGrid(
@@ -19,7 +20,7 @@ class ThriftLoadingMoreShimmer extends StatelessWidget {
               highlightColor: colors.surfaceLow,
               child: Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colors.surfaceLow,
                   borderRadius: BorderRadius.circular(16),
                 ),
               ),

--- a/apps/customer/lib/presentation/screens/thrift/widgets/thrift_screen_shimmer.dart
+++ b/apps/customer/lib/presentation/screens/thrift/widgets/thrift_screen_shimmer.dart
@@ -9,6 +9,7 @@ class ThriftScreenLoadingMoreShimmer extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = SellioTheme.of(context);
     final colors = theme.colors;
+
     return CustomScrollView(
       slivers: [
         SliverToBoxAdapter(


### PR DESCRIPTION
### fix shimmer effect bottom overflow for product list

## Screenshots/Videos (if applicable)
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/4368c686-5703-4cde-8b53-53a628522644" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">Before</p>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/ebb48850-4253-4eb0-a385-bea38d57af85" width="100%" controls></img>
      <p style="text-align:center; font-weight:bold;">After</p>
    </td>
  </tr>
</table>

