### PR TITLE
fix: update trending products API endpoint path

### DIFF
--- a/apps/customer/lib/data/core/api/api_endpoints.dart
+++ b/apps/customer/lib/data/core/api/api_endpoints.dart
@@ -15,7 +15,7 @@ class ApiEndpoints {
   static const String productsUsed = '$apiVersion/products/used';
   static const String productsFeatured = '$apiVersion/products/featured';
   static const String productsSearch = '$apiVersion/products/search';
-  static const String productsTrending = '$apiVersion/product-items/trending';
+  static const String productsTrending = '$apiVersion/products/trending';
 
   static String productById(String productId) =>
       '$apiVersion/products/$productId';

--- a/apps/customer/lib/data/models/product_summary_model.dart
+++ b/apps/customer/lib/data/models/product_summary_model.dart
@@ -20,8 +20,8 @@ class ProductSummaryModel with _$ProductSummaryModel {
     return ProductSummaryModel(
       id: json['id']?.toString() ?? '',
       title: json['title']?.toString() ?? '',
-      price: (json['price'] as num?)?.toDouble() ?? 0.0,
-      image: json['image']?.toString() ?? '',
+      price: (json['minPrice'] as num?)?.toDouble() ?? 0.0,
+      image: json['mainImageUrl']?.toString() ?? '',
       isFavorite: json['isFavorite'] as bool? ?? false,
     );
   }


### PR DESCRIPTION
- Update `productsTrending` constant in `ApiEndpoints` to use the `/products/trending` path instead of `/product-items/trending`.
 
<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/f58ddc2f-ac25-4488-b86f-7cdd7f61d32f" />
