### PR TITLE
Refactor/store creating

### DIFF
--- a/apps/seller/lib/core/navigate/app_navigator.dart
+++ b/apps/seller/lib/core/navigate/app_navigator.dart
@@ -1,9 +1,8 @@
 import 'package:authentication/authentication.dart';
 
 abstract class AppNavigator implements AuthNavigator {
-  void pushCreateStore();
+  void goToCreateStore();
 
-  void goToDashboard();
   void goToHome();
   void goToLogin();
   void pop<T extends Object?>([T? result]);

--- a/apps/seller/lib/core/navigate/app_navigator_impl.dart
+++ b/apps/seller/lib/core/navigate/app_navigator_impl.dart
@@ -44,18 +44,13 @@ class AppNavigatorImpl implements AppNavigator {
   }
 
   @override
-  void pushCreateStore() {
-    RouteGenerator.router.pushNamed(AppRoutes.createStore.name);
-  }
-
-  @override
-  void goToDashboard() {
-    RouteGenerator.router.goNamed(AppRoutes.dashboard.name);
+  void goToCreateStore() {
+    RouteGenerator.router.goNamed(AppRoutes.createStore.name);
   }
 
   @override
   void goToHome() {
-    RouteGenerator.router.goNamed(AppRoutes.createStore.name);
+    RouteGenerator.router.goNamed(AppRoutes.dashboard.name);
   }
 
   @override

--- a/apps/seller/lib/core/navigate/route_manager.dart
+++ b/apps/seller/lib/core/navigate/route_manager.dart
@@ -1,10 +1,15 @@
 import 'package:authentication/authentication.dart' as auth;
+import 'package:authentication/presentation/cubits/auth/authentication_cubit.dart';
+import 'package:authentication/presentation/cubits/auth/authentication_state.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:seller/di/injection_container.dart';
 import 'package:seller/presentation/screen/account/account_screen.dart';
 import 'package:seller/presentation/screen/create_product/create_product_screen.dart';
 import 'package:seller/presentation/screen/dashboard/dashboard_screen.dart';
+import 'package:seller/presentation/screen/main/cubit/store_cubit.dart';
+import 'package:seller/presentation/screen/main/cubit/store_state.dart';
 import 'package:seller/presentation/screen/main/seller_dashboard.dart';
 import 'package:seller/presentation/screen/orders/orders_screen.dart';
 import 'package:seller/presentation/screen/products/products_screen.dart';
@@ -23,177 +28,238 @@ class RouteGenerator {
   static final _productsNavigatorKey = GlobalKey<NavigatorState>();
   static final _accountNavigatorKey = GlobalKey<NavigatorState>();
 
-  static final GoRouter router = GoRouter(
-    navigatorKey: _rootNavigatorKey,
-    initialLocation: AppRoutes.dashboard.path,
-    routes: [
-      GoRoute(
-        name: AppRoutes.login.name,
-        path: AppRoutes.login.path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: auth.LoginScreen(
-            authRepository: sl(),
-            countryRepository: sl(),
-            authenticationCubit: sl(),
-            navigator: context.navigator,
-            showCloseButton: false,
-          ),
-        ),
-      ),
-      GoRoute(
-        name: AppRoutes.register.name,
-        path: AppRoutes.register.path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: auth.CreateAccountScreen(
-            authRepository: sl(),
-            countryRepository: sl(),
-            navigator: context.navigator,
-            showCloseButton: false,
-          ),
-        ),
-      ),
-      GoRoute(
-        name: AppRoutes.forgotPassword.name,
-        path: AppRoutes.forgotPassword.path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: auth.ForgotPasswordScreen(
-            authRepository: sl(),
-            countryRepository: sl(),
-            navigator: context.navigator,
-            showBackButton: false,
-          ),
-        ),
-      ),
-      GoRoute(
-        name: AppRoutes.otp.name,
-        path: AppRoutes.otp.path,
-        pageBuilder: (context, state) {
-          final args = state.extra as OtpArgs;
-          return MaterialPage(
+  static GoRouter? _router;
+
+  static GoRouter get router => _router ??= _createRouter();
+
+  static GoRouter _createRouter() {
+    return GoRouter(
+      navigatorKey: _rootNavigatorKey,
+      initialLocation: AppRoutes.dashboard.path,
+      refreshListenable: GoRouterRefreshListenable([
+        sl<AuthenticationCubit>(),
+        sl<StoreCubit>(),
+      ]),
+      redirect: (context, state) {
+        final authState = sl<AuthenticationCubit>().state;
+        final storeState = sl<StoreCubit>().state;
+
+        final authPaths = {
+          AppRoutes.login.path,
+          AppRoutes.register.path,
+          AppRoutes.forgotPassword.path,
+          AppRoutes.otp.path,
+          AppRoutes.resetPassword.path,
+        };
+
+        final bool onLoginPage = authPaths.contains(state.matchedLocation);
+
+        final bool hasStore = storeState is StoreLoaded;
+        final bool needsStore = storeState is StoreNotFound;
+
+        if (authState is Guest || authState is RequireLogin) {
+          return onLoginPage ? null : AppRoutes.login.path;
+        }
+
+        if (authState is! LoggedIn) {
+          return null;
+        }
+
+        final bool onStoreSetup =
+            state.matchedLocation.startsWith(AppRoutes.createStore.path);
+
+        if (needsStore) {
+          return onStoreSetup ? null : AppRoutes.createStore.path;
+        }
+
+        if (hasStore) {
+          return (onLoginPage || onStoreSetup)
+              ? AppRoutes.dashboard.path
+              : null;
+        }
+
+        return null;
+      },
+      routes: [
+        GoRoute(
+          name: AppRoutes.login.name,
+          path: AppRoutes.login.path,
+          pageBuilder: (context, state) => MaterialPage(
             key: state.pageKey,
-            child: auth.OtpScreen(
-              title: args.title ?? context.local.confirm_your_account,
-              subtitle: args.subtitle ??
-                  context.local.enter_the_4_digit_sent_to(args.phoneNumber),
-              phoneNumber: args.phoneNumber,
-              onVerify: args.onVerify,
-              onVerifySuccess: args.onVerifySuccess,
+            child: auth.LoginScreen(
               authRepository: sl(),
+              countryRepository: sl(),
+              authenticationCubit: sl(),
               navigator: context.navigator,
-              showBackButton: false,
               showCloseButton: false,
             ),
-          );
-        },
-      ),
-      GoRoute(
-        name: AppRoutes.resetPassword.name,
-        path: AppRoutes.resetPassword.path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: auth.ResetPasswordScreen(
-            authRepository: sl(),
-            countryRepository: sl(),
-            navigator: context.navigator,
-            showBackButton: false,
           ),
         ),
-      ),
-      GoRoute(
-        name: AppRoutes.createStore.name,
-        path: AppRoutes.createStore.path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: const CreateStoreScreen(),
-        ),
-      ),
-      StatefulShellRoute.indexedStack(
-        builder: (
-          BuildContext context,
-          GoRouterState state,
-          StatefulNavigationShell navigationShell,
-        ) {
-          return SellerDashboard(
+        GoRoute(
+          name: AppRoutes.register.name,
+          path: AppRoutes.register.path,
+          pageBuilder: (context, state) => MaterialPage(
             key: state.pageKey,
-            navigationShell: navigationShell,
-          );
-        },
-        branches: [
-          StatefulShellBranch(
-            navigatorKey: _dashboardNavigatorKey,
-            routes: [
-              GoRoute(
-                name: AppRoutes.dashboard.name,
-                path: AppRoutes.dashboard.path,
-                pageBuilder: (context, state) => MaterialPage(
-                  key: state.pageKey,
-                  child: const DashboardScreen(),
-                ),
-              ),
-            ],
+            child: auth.CreateAccountScreen(
+              authRepository: sl(),
+              countryRepository: sl(),
+              navigator: context.navigator,
+              showCloseButton: false,
+            ),
           ),
-          StatefulShellBranch(
-            navigatorKey: _ordersNavigatorKey,
-            routes: [
-              GoRoute(
-                name: AppRoutes.orders.name,
-                path: AppRoutes.orders.path,
-                pageBuilder: (context, state) => MaterialPage(
-                  key: state.pageKey,
-                  child: const OrdersScreen(),
-                ),
-              ),
-            ],
+        ),
+        GoRoute(
+          name: AppRoutes.forgotPassword.name,
+          path: AppRoutes.forgotPassword.path,
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: auth.ForgotPasswordScreen(
+              authRepository: sl(),
+              countryRepository: sl(),
+              navigator: context.navigator,
+              showBackButton: false,
+            ),
           ),
-          StatefulShellBranch(
-            navigatorKey: _createProductNavigatorKey,
-            routes: [
-              GoRoute(
-                name: AppRoutes.createProduct.name,
-                path: AppRoutes.createProduct.path,
-                pageBuilder: (context, state) => MaterialPage(
-                  key: state.pageKey,
-                  child: const CreateProductScreen(),
-                ),
+        ),
+        GoRoute(
+          name: AppRoutes.otp.name,
+          path: AppRoutes.otp.path,
+          pageBuilder: (context, state) {
+            final args = state.extra as OtpArgs;
+            return MaterialPage(
+              key: state.pageKey,
+              child: auth.OtpScreen(
+                title: args.title ?? context.local.confirm_your_account,
+                subtitle: args.subtitle ??
+                    context.local.enter_the_4_digit_sent_to(args.phoneNumber),
+                phoneNumber: args.phoneNumber,
+                onVerify: args.onVerify,
+                onVerifySuccess: args.onVerifySuccess,
+                authRepository: sl(),
+                navigator: context.navigator,
+                showBackButton: false,
+                showCloseButton: false,
               ),
-            ],
+            );
+          },
+        ),
+        GoRoute(
+          name: AppRoutes.resetPassword.name,
+          path: AppRoutes.resetPassword.path,
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: auth.ResetPasswordScreen(
+              authRepository: sl(),
+              countryRepository: sl(),
+              navigator: context.navigator,
+              showBackButton: false,
+            ),
           ),
-          StatefulShellBranch(
-            navigatorKey: _productsNavigatorKey,
-            routes: [
-              GoRoute(
-                name: AppRoutes.products.name,
-                path: AppRoutes.products.path,
-                pageBuilder: (context, state) => MaterialPage(
-                  key: state.pageKey,
-                  child: const ProductsScreen(),
-                ),
-              ),
-            ],
+        ),
+        GoRoute(
+          name: AppRoutes.createStore.name,
+          path: AppRoutes.createStore.path,
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: const CreateStoreScreen(),
           ),
-          StatefulShellBranch(
-            navigatorKey: _accountNavigatorKey,
-            routes: [
-              GoRoute(
-                name: AppRoutes.account.name,
-                path: AppRoutes.account.path,
-                pageBuilder: (context, state) => MaterialPage(
-                  key: state.pageKey,
-                  child: const AccountScreen(),
+        ),
+        StatefulShellRoute.indexedStack(
+          builder: (
+            BuildContext context,
+            GoRouterState state,
+            StatefulNavigationShell navigationShell,
+          ) {
+            return SellerDashboard(
+              key: state.pageKey,
+              navigationShell: navigationShell,
+            );
+          },
+          branches: [
+            StatefulShellBranch(
+              navigatorKey: _dashboardNavigatorKey,
+              routes: [
+                GoRoute(
+                  name: AppRoutes.dashboard.name,
+                  path: AppRoutes.dashboard.path,
+                  pageBuilder: (context, state) => MaterialPage(
+                    key: state.pageKey,
+                    child: const DashboardScreen(),
+                  ),
                 ),
-              ),
+              ],
+            ),
+            StatefulShellBranch(
+              navigatorKey: _ordersNavigatorKey,
+              routes: [
+                GoRoute(
+                  name: AppRoutes.orders.name,
+                  path: AppRoutes.orders.path,
+                  pageBuilder: (context, state) => MaterialPage(
+                    key: state.pageKey,
+                    child: const OrdersScreen(),
+                  ),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              navigatorKey: _createProductNavigatorKey,
+              routes: [
+                GoRoute(
+                  name: AppRoutes.createProduct.name,
+                  path: AppRoutes.createProduct.path,
+                  pageBuilder: (context, state) => MaterialPage(
+                    key: state.pageKey,
+                    child: const CreateProductScreen(),
+                  ),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              navigatorKey: _productsNavigatorKey,
+              routes: [
+                GoRoute(
+                  name: AppRoutes.products.name,
+                  path: AppRoutes.products.path,
+                  pageBuilder: (context, state) => MaterialPage(
+                    key: state.pageKey,
+                    child: const ProductsScreen(),
+                  ),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              navigatorKey: _accountNavigatorKey,
+              routes: [
+                GoRoute(
+                  name: AppRoutes.account.name,
+                  path: AppRoutes.account.path,
+                  pageBuilder: (context, state) => MaterialPage(
+                    key: state.pageKey,
+                    child: const AccountScreen(),
+                  ),
+                ),
+              ],
+            ),
             ],
           ),
         ],
+      errorBuilder: (context, state) => Scaffold(
+        body: Center(
+          child: Text('${context.local.error}: ${state.error}'),
+        ),
       ),
-    ],
-    errorBuilder: (context, state) => Scaffold(
-      body: Center(
-        child: Text('${context.local.error}: ${state.error}'),
-      ),
-    ),
-  );
+    );
+  }
+}
+
+class GoRouterRefreshListenable extends ChangeNotifier {
+  GoRouterRefreshListenable(List<BlocBase> blocs) {
+    for (final bloc in blocs) {
+      bloc.stream.listen((_) {
+        if (!hasListeners) return;
+        notifyListeners();
+      });
+    }
+  }
 }

--- a/apps/seller/lib/data/datasource/product_datasource.dart
+++ b/apps/seller/lib/data/datasource/product_datasource.dart
@@ -2,6 +2,4 @@ import '../../domain/entity/create_product_params.dart';
 
 abstract class ProductDataSource {
   Future<void> createProduct(AddProduct params);
-
-  Future<String> getOwnerStoreId();
 }

--- a/apps/seller/lib/data/datasource/remote/product_remote_datasource.dart
+++ b/apps/seller/lib/data/datasource/remote/product_remote_datasource.dart
@@ -41,10 +41,4 @@ class ProductRemoteDataSource implements ProductDataSource {
       data: formData,
     );
   }
-
-  @override
-  Future<String> getOwnerStoreId() async {
-    final response = await _apiClient.get(ApiEndpoints.storeOwner);
-    return response.data['id'] as String;
-  }
 }

--- a/apps/seller/lib/data/datasource/remote/store_remote_datasource.dart
+++ b/apps/seller/lib/data/datasource/remote/store_remote_datasource.dart
@@ -3,4 +3,6 @@ import '../../models/store/store_creation_response.dart';
 
 abstract class StoreRemoteDataSource {
   Future<StoreCreationResponse> createStore(CreateStoreRequest request);
+
+  Future<String> getStoreId();
 }

--- a/apps/seller/lib/data/datasource/remote/store_remote_datasource_impl.dart
+++ b/apps/seller/lib/data/datasource/remote/store_remote_datasource_impl.dart
@@ -19,4 +19,14 @@ class StoreRemoteDataSourceImpl implements StoreRemoteDataSource {
 
     return StoreCreationResponse.fromJson(response.data);
   }
+
+  @override
+  Future<String> getStoreId() async {
+    final response = await _apiClient.get(ApiEndpoints.storeOwner);
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return (data['id'] ?? data['_id'])?.toString() ?? '';
+    }
+    return '';
+  }
 }

--- a/apps/seller/lib/data/repository/product_repository_impl.dart
+++ b/apps/seller/lib/data/repository/product_repository_impl.dart
@@ -16,11 +16,4 @@ class ProductRepositoryImpl implements ProductRepository {
       await _dataSource.createProduct(params);
     });
   }
-
-  @override
-  Future<Result<String>> getOwnerStoreId() {
-    return RepositoryCallHandler.call<String>(() async {
-      return _dataSource.getOwnerStoreId();
-    });
-  }
 }

--- a/apps/seller/lib/data/repository/store_repository_impl.dart
+++ b/apps/seller/lib/data/repository/store_repository_impl.dart
@@ -33,4 +33,11 @@ class StoreRepositoryImpl implements StoreRepository {
       );
     });
   }
+
+  @override
+  Future<Result<String>> getStoreId() {
+    return RepositoryCallHandler.call<String>(() async {
+      return _remoteDataSource.getStoreId();
+    });
+  }
 }

--- a/apps/seller/lib/di/modules/bloc_module.dart
+++ b/apps/seller/lib/di/modules/bloc_module.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:seller/presentation/screen/create_product/cubit/create_product_cubit.dart';
+import 'package:seller/presentation/screen/main/cubit/store_cubit.dart';
 import 'package:seller/presentation/screen/orders/cubit/seller_orders_cubit.dart';
 
 import '../../data/datasource/fake/fake_create_product_datasource.dart';
@@ -7,8 +8,10 @@ import '../../data/datasource/fake/fake_create_product_datasource.dart';
 class BlocModule {
   static void register(GetIt sl) {
     sl.registerFactory(() => SellerOrdersCubit(sl()));
+    sl.registerLazySingleton(() => StoreCubit(sl(), sl()));
     sl.registerFactory(() => CreateProductCubit(
           productRepository: sl(),
+          storeRepository: sl(),
           authCubit: sl(),
           metadataDataSource: sl<FakeCreateProductDataSource>(),
         ));

--- a/apps/seller/lib/domain/repository/product_repository.dart
+++ b/apps/seller/lib/domain/repository/product_repository.dart
@@ -4,6 +4,4 @@ import '../entity/create_product_params.dart';
 
 abstract class ProductRepository {
   Future<Result<void>> createProduct(AddProduct params);
-
-  Future<Result<String>> getOwnerStoreId();
 }

--- a/apps/seller/lib/domain/repository/store_repository.dart
+++ b/apps/seller/lib/domain/repository/store_repository.dart
@@ -5,4 +5,6 @@ import '../entity/store_seller.dart';
 
 abstract class StoreRepository {
   Future<Result<StoreSeller>> createStore(CreateStoreRequest request);
+
+  Future<Result<String>> getStoreId();
 }

--- a/apps/seller/lib/main.dart
+++ b/apps/seller/lib/main.dart
@@ -7,11 +7,12 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/localization/l10n/app_localizations.dart';
-import 'core/navigate/navigation_extensions.dart';
 import 'core/navigate/route_manager.dart';
 import 'di/injection_container.dart';
 import 'domain/repository/category_repository.dart';
+import 'domain/repository/product_repository.dart';
 import 'domain/repository/store_repository.dart';
+import 'presentation/screen/main/cubit/store_cubit.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -42,11 +43,13 @@ class MyApp extends StatelessWidget {
         RepositoryProvider(create: (_) => sl<CountryRepository>()),
         RepositoryProvider(create: (_) => sl<StoreRepository>()),
         RepositoryProvider(create: (_) => sl<CategoryRepository>()),
+        RepositoryProvider(create: (_) => sl<ProductRepository>()),
         RepositoryProvider(create: (_) => sl<ImagePickerService>()),
       ],
       child: MultiBlocProvider(
         providers: [
           BlocProvider(create: (_) => sl<AuthenticationCubit>()),
+          BlocProvider(create: (_) => sl<StoreCubit>()),
         ],
         child: Builder(
           builder: (context) {
@@ -66,17 +69,7 @@ class MyApp extends StatelessWidget {
                   ],
                   supportedLocales: LocaleCubit.supportedLocales,
                   builder: (context, child) {
-                    return BlocListener<AuthenticationCubit,
-                        AuthenticationState>(
-                      listener: (context, state) {
-                        if (state is RequireLogin || state is Guest) {
-                          context.navigator.pushLogin();
-                        } else if (state is LoggedIn) {
-                          context.navigator.goToHome();
-                        }
-                      },
-                      child: child!,
-                    );
+                    return child!;
                   },
                 );
               },

--- a/apps/seller/lib/presentation/screen/create_product/cubit/create_product_cubit.dart
+++ b/apps/seller/lib/presentation/screen/create_product/cubit/create_product_cubit.dart
@@ -5,19 +5,23 @@ import '../../../../data/datasource/fake/fake_create_product_datasource.dart';
 import '../../../../domain/entity/create_product_params.dart';
 import '../../../../domain/entity/product_item.dart';
 import '../../../../domain/repository/product_repository.dart';
+import '../../../../domain/repository/store_repository.dart';
 import '../../../../domain/validators/product_validation_error.dart';
 import '../../../../domain/validators/product_validators.dart';
 import 'create_product_state.dart';
 
 class CreateProductCubit extends Cubit<CreateProductState> {
   final ProductRepository _productRepository;
+  final StoreRepository _storeRepository;
   final FakeCreateProductDataSource _metadataDataSource;
 
   CreateProductCubit({
     required ProductRepository productRepository,
+    required StoreRepository storeRepository,
     required AuthenticationCubit authCubit,
     required FakeCreateProductDataSource metadataDataSource,
   })  : _productRepository = productRepository,
+        _storeRepository = storeRepository,
         _metadataDataSource = metadataDataSource,
         super(const CreateProductInitial());
 
@@ -182,7 +186,7 @@ class CreateProductCubit extends Cubit<CreateProductState> {
 
     try {
       // 0. Get storeId dynamically based on the current user's token
-      final storeResult = await _productRepository.getOwnerStoreId();
+      final storeResult = await _storeRepository.getStoreId();
 
       String? storeId;
       storeResult.fold(

--- a/apps/seller/lib/presentation/screen/main/cubit/store_cubit.dart
+++ b/apps/seller/lib/presentation/screen/main/cubit/store_cubit.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:authentication/presentation/cubits/auth/authentication_cubit.dart';
+import 'package:authentication/presentation/cubits/auth/authentication_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../domain/repository/store_repository.dart';
+import 'store_state.dart';
+
+class StoreCubit extends Cubit<StoreState> {
+  final StoreRepository _storeRepository;
+  final AuthenticationCubit _authCubit;
+  StreamSubscription? _authSubscription;
+
+  StoreCubit(this._storeRepository, this._authCubit)
+      : super(const StoreInitial()) {
+    _authSubscription = _authCubit.stream.listen((authState) {
+      if (authState is LoggedIn) {
+        checkStoreExistence();
+      } else if (authState is Guest || authState is RequireLogin) {
+        emit(const StoreInitial());
+      }
+    });
+
+    if (_authCubit.state is LoggedIn) {
+      checkStoreExistence();
+    }
+  }
+
+  Future<void> checkStoreExistence({bool force = false}) async {
+    if (!force &&
+        (state is StoreLoading ||
+            state is StoreLoaded ||
+            state is StoreNotFound)) {
+      return;
+    }
+
+    emit(const StoreLoading());
+
+    final result = await _storeRepository.getStoreId();
+
+    result.fold(
+      onSuccess: (id) {
+        if (id.isNotEmpty) {
+          emit(StoreLoaded(id));
+        } else {
+          emit(const StoreNotFound());
+        }
+      },
+      onFailure: (failure) {
+        if (failure.code == 'STORE_004') {
+          emit(const StoreNotFound());
+        } else {
+          emit(StoreError(failure.message));
+        }
+      },
+    );
+  }
+
+  void setStoreLoaded(String storeId) {
+    emit(StoreLoaded(storeId));
+  }
+
+  @override
+  Future<void> close() {
+    _authSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/apps/seller/lib/presentation/screen/main/cubit/store_state.dart
+++ b/apps/seller/lib/presentation/screen/main/cubit/store_state.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+abstract class StoreState extends Equatable {
+  const StoreState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class StoreInitial extends StoreState {
+  const StoreInitial();
+}
+
+class StoreLoading extends StoreState {
+  const StoreLoading();
+}
+
+class StoreLoaded extends StoreState {
+  final String storeId;
+
+  const StoreLoaded(this.storeId);
+
+  @override
+  List<Object?> get props => [storeId];
+}
+
+class StoreNotFound extends StoreState {
+  const StoreNotFound();
+}
+
+class StoreError extends StoreState {
+  final String message;
+
+  const StoreError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/apps/seller/lib/presentation/screen/store_setup/create_store_screen.dart
+++ b/apps/seller/lib/presentation/screen/store_setup/create_store_screen.dart
@@ -35,7 +35,7 @@ class _CreateStoreScreenContent extends StatelessWidget {
     return CreateStoreListeners(
       child: BlocBuilder<CreateStoreCubit, CreateStoreState>(
         builder: (context, state) {
-          final isSubmitting = state is CreateStoreSubmitting;
+          final isLoading = state is CreateStoreSubmitting;
 
           return Stack(
             children: [
@@ -46,7 +46,7 @@ class _CreateStoreScreenContent extends StatelessWidget {
                   child: CreateStoreBody(),
                 ),
               ),
-              if (isSubmitting)
+              if (isLoading)
                 Container(
                   color: Colors.black.withOpacity(0.3),
                   child: const Center(

--- a/apps/seller/lib/presentation/screen/store_setup/cubit/create_store_cubit.dart
+++ b/apps/seller/lib/presentation/screen/store_setup/cubit/create_store_cubit.dart
@@ -53,7 +53,9 @@ class CreateStoreCubit extends Cubit<CreateStoreState> {
           ));
         }
       },
-      onFailure: (failure) {},
+      onFailure: (failure) {
+        emit(CreateStoreFailure(failure.message));
+      },
     );
   }
 

--- a/apps/seller/lib/presentation/screen/store_setup/cubit/create_store_state.dart
+++ b/apps/seller/lib/presentation/screen/store_setup/cubit/create_store_state.dart
@@ -128,10 +128,10 @@ class CreateStoreSuccess extends CreateStoreState {
 }
 
 class CreateStoreFailure extends CreateStoreState {
-  final String errorMessage;
+  final String message;
 
-  const CreateStoreFailure(this.errorMessage);
+  const CreateStoreFailure(this.message);
 
   @override
-  List<Object?> get props => [errorMessage];
+  List<Object?> get props => [message];
 }

--- a/apps/seller/lib/presentation/screen/store_setup/widget/create_store_body.dart
+++ b/apps/seller/lib/presentation/screen/store_setup/widget/create_store_body.dart
@@ -40,6 +40,15 @@ class _CreateStoreBodyState extends State<CreateStoreBody> {
     _setupListeners();
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final cubitState = context.read<CreateStoreCubit>().state;
+    if (cubitState is CreateStoreIdle && _lastIdleState == null) {
+      _lastIdleState = cubitState;
+    }
+  }
+
   void _setupListeners() {
     final cubit = context.read<CreateStoreCubit>();
     _storeNameController.addListener(() {

--- a/apps/seller/lib/presentation/screen/store_setup/widget/create_store_listeners.dart
+++ b/apps/seller/lib/presentation/screen/store_setup/widget/create_store_listeners.dart
@@ -1,8 +1,8 @@
 import 'package:design_system/design_system.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:seller/core/localization/l10n/localization_service.dart';
-import 'package:seller/core/navigate/navigation_extensions.dart';
+import 'package:seller/presentation/screen/main/cubit/store_cubit.dart';
 
 import '../cubit/create_store_cubit.dart';
 import '../cubit/create_store_state.dart';
@@ -20,7 +20,7 @@ class CreateStoreListeners extends StatelessWidget {
     return BlocListener<CreateStoreCubit, CreateStoreState>(
       listener: (context, state) {
         if (state is CreateStoreSuccess) {
-          _handleSuccess(context);
+          _handleSuccess(context, state);
         } else if (state is CreateStoreFailure) {
           _handleError(context, state);
         }
@@ -29,23 +29,19 @@ class CreateStoreListeners extends StatelessWidget {
     );
   }
 
-  void _handleSuccess(BuildContext context) {
+  void _handleSuccess(BuildContext context, CreateStoreSuccess state) {
     SnackBarHelper.showSuccess(
       context,
       context.local.store_created_successfully,
       title: context.local.success,
     );
-    Future.delayed(const Duration(milliseconds: 500), () {
-      if (context.mounted) {
-        context.navigator.goToDashboard();
-      }
-    });
+    context.read<StoreCubit>().setStoreLoaded(state.store.id);
   }
 
   void _handleError(BuildContext context, CreateStoreFailure state) {
     SnackBarHelper.showError(
       context,
-      state.errorMessage,
+      state.message,
       title: context.local.error,
     );
   }

--- a/packages/design_system/lib/widgets/sellio_picker_field.dart
+++ b/packages/design_system/lib/widgets/sellio_picker_field.dart
@@ -229,32 +229,43 @@ class _SellioPickerFieldState<T> extends State<SellioPickerField<T>> {
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
+    final isFocused = _focusNode.hasFocus;
 
     return CompositedTransformTarget(
       link: _layerLink,
       child: Focus(
         focusNode: _focusNode,
         canRequestFocus: widget.enabled,
-        child: Opacity(
-          opacity: widget.enabled ? 1.0 : 0.6,
-          child: SellioTextField(
-            controller: _displayController,
-            hintText: widget.hintText,
-            prefixIcon: widget.prefixIcon,
-            prefixIconPadding: widget.prefixIconPadding,
-            readOnly: true,
-            enabled: widget.enabled,
-            errorMessage: widget.errorText,
-            isError: widget.errorText != null,
-            suffixIcon:
-                widget.suffixIcon ??
-                Icon(
-                  Icons.arrow_drop_down,
-                  color: widget.enabled
-                      ? colors.body
-                      : colors.body.withValues(alpha: 0.5),
-                ),
-            onTap: _toggleFocus,
+        onFocusChange: (hasFocus) {
+          setState(() {}); // Rebuild to update visual state when focus changes
+        },
+        child: GestureDetector(
+          onTap: _toggleFocus,
+          behavior: HitTestBehavior.opaque,
+          child: Opacity(
+            opacity: widget.enabled ? 1.0 : 0.6,
+            child: IgnorePointer(
+              ignoring: true,
+              child: SellioTextField(
+                key: ValueKey('${widget.errorText}_$isFocused'),
+                controller: _displayController,
+                hintText: widget.hintText,
+                prefixIcon: widget.prefixIcon,
+                prefixIconPadding: widget.prefixIconPadding,
+                readOnly: true,
+                enabled: widget.enabled,
+                errorMessage: isFocused ? null : widget.errorText,
+                isError: isFocused ? false : (widget.errorText != null),
+                suffixIcon:
+                    widget.suffixIcon ??
+                    Icon(
+                      Icons.arrow_drop_down,
+                      color: widget.enabled
+                          ? colors.body
+                          : colors.body.withValues(alpha: 0.5),
+                    ),
+              ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION

## What Changed
**Global State Management**: Introduced a root-level `StoreCubit `(Singleton) that manages the store's lifecycle. It automatically observes AuthenticationCubit to trigger checks on login and clear data on logout.


## Checklist
- [x] New users _(without stores)_ are correctly redirected to /create_store after login.
- [x] Existing users _(with stores)_ land directly on /dashboard.
- [x] refactor related code
- [x] improve related ui

